### PR TITLE
Use explicit leadership email list for auth

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -12,8 +12,21 @@ const SHEET_AUDIT = 'Audit';
 const STATIC_DEVS = ['skhun@dublincleaners.com', 'ss.sku@protonmail.com'];
 const DEV_PROP_KEY = 'DEV_LIST';
 
-// Allow only Leadership Team emails (domain specific or explicit list)
-const LT_DOMAIN = 'dublincleaners.com';
+// Allowed Leadership Team email addresses
+const LT_EMAILS = [
+  'skhun@dublincleaners.com',
+  'ss.sku@protonmail.com',
+  'brianmbutler77@gmail.com',
+  'brianbutler@dublincleaners.com',
+  'rbrown5940@gmail.com',
+  'rbrown@dublincleaners.com',
+  'davepdublincleaners@gmail.com',
+  'lisamabr@yahoo.com',
+  'dddale40@gmail.com',
+  'nismosil85@gmail.com',
+  'mlackey@dublincleaners.com',
+  'china99@mail.com'
+];
 
 // Google Chat webhook for notifications
 const CHAT_WEBHOOK = 'https://chat.googleapis.com/v1/spaces/...'; // replace with real webhook
@@ -27,7 +40,7 @@ function getUserEmail() {
 
 /** Check if user is part of Leadership Team. */
 function isLtUser(email) {
-  return email && email.toLowerCase().endsWith('@' + LT_DOMAIN);
+  return email ? LT_EMAILS.includes(email.toLowerCase()) : false;
 }
 
 /** Get developer emails including dynamic list from script properties. */

--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@ This serves `index.html` and enables ES modules. No build step is required for A
 
 ## Auth Flow
 - The app relies on `Session.getActiveUser().getEmail()` to identify the signed-in Google account.
-- Only emails within the `dublincleaners.com` domain can access the main UI.
+- Only the following Leadership Team email addresses can access the main UI by default:
+  `skhun@dublincleaners.com`, `ss.sku@protonmail.com`, `brianmbutler77@gmail.com`, `brianbutler@dublincleaners.com`,
+  `rbrown5940@gmail.com`, `rbrown@dublincleaners.com`, `davepdublincleaners@gmail.com`, `lisamabr@yahoo.com`,
+  `dddale40@gmail.com`, `nismosil85@gmail.com`, `mlackey@dublincleaners.com`, `china99@mail.com`.
+  Update `LT_EMAILS` in `Code.gs` to modify this list.
 - The Developer Console is restricted to predefined developer emails or those added via the console.
 
 ## Testing


### PR DESCRIPTION
## Summary
- Restrict UI access to a hard-coded list of Leadership Team email addresses
- Document allowed emails and pointer to `LT_EMAILS` config

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948a98781083228d5f116a3e4aea37