### PR TITLE
Use OAuth userinfo to determine active user

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -33,9 +33,27 @@ const CHAT_WEBHOOK = 'https://chat.googleapis.com/v1/spaces/...'; // replace wit
 
 /** Utility helpers */
 
-/** Returns the active user's email. */
+/** Returns the signed-in user's email using OAuth for cross-domain accounts. */
 function getUserEmail() {
-  return Session.getActiveUser().getEmail();
+  let email = Session.getActiveUser().getEmail();
+  if (email) {
+    return email;
+  }
+
+  try {
+    const token = ScriptApp.getOAuthToken();
+    const response = UrlFetchApp.fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
+      headers: { Authorization: 'Bearer ' + token },
+      muteHttpExceptions: true,
+    });
+    const data = JSON.parse(response.getContentText());
+    if (data.email) {
+      return data.email;
+    }
+  } catch (err) {
+    // Ignore and fall through.
+  }
+  return '';
 }
 
 /** Check if user is part of Leadership Team. */

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This serves `index.html` and enables ES modules. No build step is required for A
 - Maintain WCAG AA contrast; interactive elements follow Google Material patterns.
 
 ## Auth Flow
-- The app relies on `Session.getActiveUser().getEmail()` to identify the signed-in Google account.
+- The app identifies the signed-in Google account using the OAuth `userinfo` endpoint, falling back to `Session.getActiveUser()` when possible.
 - Only the following Leadership Team email addresses can access the main UI by default:
   `skhun@dublincleaners.com`, `ss.sku@protonmail.com`, `brianmbutler77@gmail.com`, `brianbutler@dublincleaners.com`,
   `rbrown5940@gmail.com`, `rbrown@dublincleaners.com`, `davepdublincleaners@gmail.com`, `lisamabr@yahoo.com`,

--- a/appsscript.json
+++ b/appsscript.json
@@ -1,0 +1,10 @@
+{
+  "timeZone": "America/New_York",
+  "exceptionLogging": "STACKDRIVER",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/script.send_mail",
+    "https://www.googleapis.com/auth/script.external_request",
+    "https://www.googleapis.com/auth/userinfo.email"
+  ]
+}


### PR DESCRIPTION
## Summary
- Fetch user email via Google OAuth userinfo endpoint to support cross-domain accounts
- Document OAuth-based auth flow and leadership list maintenance
- Declare required OAuth scopes in `appsscript.json`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68948f7d299483228eb01424294b8834