### PR TITLE
chore: disable oauth

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -33,27 +33,10 @@ const CHAT_WEBHOOK = 'https://chat.googleapis.com/v1/spaces/...'; // replace wit
 
 /** Utility helpers */
 
-/** Returns the signed-in user's email using OAuth for cross-domain accounts. */
+/** Returns the active user's email without invoking OAuth. */
 function getUserEmail() {
-  let email = Session.getActiveUser().getEmail();
-  if (email) {
-    return email;
-  }
-
-  try {
-    const token = ScriptApp.getOAuthToken();
-    const response = UrlFetchApp.fetch('https://www.googleapis.com/oauth2/v2/userinfo', {
-      headers: { Authorization: 'Bearer ' + token },
-      muteHttpExceptions: true,
-    });
-    const data = JSON.parse(response.getContentText());
-    if (data.email) {
-      return data.email;
-    }
-  } catch (err) {
-    // Ignore and fall through.
-  }
-  return '';
+  const email = Session.getActiveUser().getEmail();
+  return email || 'anonymous@example.com';
 }
 
 /** Check if user is part of Leadership Team. */
@@ -73,13 +56,8 @@ function isDeveloper(email) {
   return getDeveloperEmails().includes(email);
 }
 
-/** Ensure active user authorized; throw otherwise. */
-function assertAuthorized() {
-  const email = getUserEmail();
-  if (!isLtUser(email)) {
-    throw new Error('Unauthorized');
-  }
-}
+/** Authentication temporarily disabled; all users allowed. */
+function assertAuthorized() {}
 
 /** Append JSON diff to Audit sheet */
 function logAudit(entry) {


### PR DESCRIPTION
## Summary
- drop Google OAuth call and fall back on session email or a placeholder
- temporarily disable authorization checks while auth is being rebuilt

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6894958888dc8322927bb15cf99ca429