### PR TITLE
fix: enable modal continue navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,6 +11,7 @@
     .m-2{margin:0.5rem;} .text-center{text-align:center;} .text-sm{font-size:0.875rem;}
     .btn{background:#1a73e8;color:#fff;padding:0.5rem 1rem;border:none;border-radius:4px;}
     .btn:disabled{background:#9e9e9e;}
+    .btn:focus-visible{outline:3px solid #000;outline-offset:2px;}
     .input{padding:0.5rem;border:1px solid #ccc;border-radius:4px;}
     .nav-mobile{position:fixed;bottom:0;left:0;right:0;background:#fff;border-top:1px solid #ddd;}
     .nav-desktop{position:fixed;top:0;bottom:0;width:200px;background:#fff;border-right:1px solid #ddd;}
@@ -47,9 +48,10 @@
   <main id="app" class="main p-4"></main>
 
   <!-- Flowchart modal -->
-  <div id="flowModal" class="modal hidden">
+  <div id="flowModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="flowTitle" aria-hidden="true" tabindex="-1">
     <div class="modal-content">
       <div class="m-2">
+        <h2 id="flowTitle" class="text-center">Request Process</h2>
         <div class="mermaid">
           graph LR
             A[Submit] --> B{Review}
@@ -57,7 +59,7 @@
             B -->|Deny| D[Notify]
         </div>
         <label class="flex m-2"><input type="checkbox" id="ackChk" class="m-2">I understand</label>
-        <button id="ackBtn" class="btn" disabled>Continue</button>
+        <button id="ackBtn" class="btn" type="button" disabled aria-disabled="true">Continue</button>
       </div>
     </div>
   </div>
@@ -112,31 +114,33 @@
     function showFlowModal(){
       const modal = document.getElementById('flowModal');
       modal.classList.remove('hidden');
+      modal.removeAttribute('aria-hidden');
+      modal.focus();
+
       const chk = document.getElementById('ackChk');
       const btn = document.getElementById('ackBtn');
+
       // reset state each time modal is shown
       chk.checked = false;
-      // ensure the continue button starts disabled
-      btn.setAttribute('disabled', '');
+      btn.disabled = true;
+      btn.setAttribute('aria-disabled','true');
 
+      // enable the button only when acknowledgement checkbox is checked
       const toggle = () => {
-        if (chk.checked) {
-          btn.removeAttribute('disabled');
-        } else {
-          btn.setAttribute('disabled', '');
-        }
+        const enabled = chk.checked;
+        btn.disabled = !enabled;
+        btn.setAttribute('aria-disabled', String(!enabled));
       };
-      // reset any prior handlers then wire up fresh ones
-      chk.onclick = null;
-      chk.addEventListener('click', toggle);
+      chk.onchange = toggle;
 
-      btn.onclick = () => {
-        if (btn.hasAttribute('disabled')) return;
-
+      // dismiss the modal and return to the main view
+      const handleContinue = () => {
+        if (btn.disabled) return;
         modal.classList.add('hidden');
-        // return user to the main request page after acknowledging
+        modal.setAttribute('aria-hidden','true');
         render('request');
       };
+      btn.addEventListener('click', handleContinue, { once: true });
     }
 
     /** My Requests */
@@ -203,6 +207,8 @@
     }).getDeveloperEmails();
 
     render('request');
+    // Display intro flow modal before user interacts with the app
+    showFlowModal();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- enable modal Continue button by wiring click handler that hides modal and renders main page
- add ARIA attributes and focus styles for accessibility
- show introductory modal on first load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6899fa0cae9c8322acd2a03d0691cbb7