### PR TITLE
fix: enable intro modal dismissal

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,6 +26,17 @@
   <script type="module" src="https://www.gstatic.com/charts/loader.js"></script>
 </head>
 <body>
+  <!-- Intro modal displayed on first load -->
+  <div id="introModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="introTitle" tabindex="-1">
+    <div class="modal-content">
+      <div class="m-2">
+        <h2 id="introTitle" class="text-center">Welcome</h2>
+        <label class="flex m-2"><input type="checkbox" id="ack" class="m-2">I understand</label>
+        <button id="btnContinue" class="btn" type="button" disabled aria-disabled="true">Continue</button>
+      </div>
+    </div>
+  </div>
+
   <!-- Sidebar for desktop -->
   <nav class="nav-desktop p-2">
     <ul>
@@ -45,7 +56,8 @@
     <button id="devNavM" class="btn flex-1 hidden" data-view="dev">Dev</button>
   </nav>
 
-  <main id="app" class="main p-4"></main>
+  <!-- Main app content hidden until modal is dismissed -->
+  <main id="app" class="main p-4 hidden" aria-hidden="true" tabindex="-1"></main>
 
   <!-- Flowchart modal -->
   <div id="flowModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="flowTitle" aria-hidden="true" tabindex="-1">
@@ -77,6 +89,39 @@
       analytics: renderAnalytics,
       dev: renderDev
     };
+
+    // Bind intro modal behaviour once the DOM is ready
+    document.addEventListener('DOMContentLoaded', bindIntroModal);
+
+    function bindIntroModal(){
+      const modal = document.getElementById('introModal');
+      const app = document.getElementById('app');
+      const chk = document.getElementById('ack');
+      const btn = document.getElementById('btnContinue');
+
+      modal.focus(); // move focus into the modal for screen readers
+
+      // Toggle the Continue button when the acknowledgement is checked
+      chk.addEventListener('change', () => {
+        const enabled = chk.checked;
+        btn.disabled = !enabled;
+        btn.setAttribute('aria-disabled', String(!enabled));
+      });
+
+      // Hide modal and show main app content when user continues
+      btn.addEventListener('click', () => {
+        if (btn.disabled) return; // guard against accidental activation
+        modal.classList.add('hidden');
+        modal.setAttribute('aria-hidden','true');
+
+        app.classList.remove('hidden');
+        app.removeAttribute('aria-hidden');
+        app.focus(); // move focus to the main app region
+
+        // Optional routing hash update
+        location.hash = '#main';
+      });
+    }
 
     document.querySelectorAll('button[data-view]').forEach(btn=>{
       btn.addEventListener('click', ()=>{
@@ -207,8 +252,8 @@
     }).getDeveloperEmails();
 
     render('request');
-    // Display intro flow modal before user interacts with the app
-    showFlowModal();
+    // Initial modal blocks interaction until user acknowledges.
+    // `bindIntroModal` sets up its own event handlers on DOMContentLoaded.
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add accessible intro modal with acknowledgment checkbox
- reveal main app content and update hash when continue is clicked
- focus management for modal and main content

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899ff06c208832292a9a8c4ee036664