### PR TITLE
feat: remove intro modal

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,16 +27,6 @@
   <script src="https://www.gstatic.com/charts/loader.js"></script>
 </head>
 <body>
-  <!-- Intro modal displayed on first load -->
-  <div id="introModal" class="modal" role="dialog" aria-modal="true" aria-labelledby="introTitle" tabindex="-1">
-    <div class="modal-content">
-      <div class="m-2">
-        <h2 id="introTitle" class="text-center">Welcome</h2>
-        <label class="flex m-2"><input type="checkbox" id="ack" class="m-2">I understand</label>
-        <button id="btnContinue" class="btn" type="button" disabled aria-disabled="true">Continue</button>
-      </div>
-    </div>
-  </div>
 
   <!-- Sidebar for desktop -->
   <nav class="nav-desktop p-2">
@@ -57,8 +47,8 @@
     <button id="devNavM" class="btn flex-1 hidden" data-view="dev">Dev</button>
   </nav>
 
-  <!-- Main app content hidden until modal is dismissed -->
-  <main id="app" class="main p-4 hidden" aria-hidden="true" tabindex="-1"></main>
+  <!-- Main app content -->
+  <main id="app" class="main p-4" tabindex="-1"></main>
 
   <!-- Flowchart modal -->
   <div id="flowModal" class="modal hidden" role="dialog" aria-modal="true" aria-labelledby="flowTitle" aria-hidden="true" tabindex="-1">
@@ -91,42 +81,6 @@
       dev: renderDev
     };
 
-    // Bind intro modal behaviour once the DOM is ready
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', bindIntroModal);
-    } else {
-      bindIntroModal();
-    }
-
-    function bindIntroModal(){
-      const modal = document.getElementById('introModal');
-      const app = document.getElementById('app');
-      const chk = document.getElementById('ack');
-      const btn = document.getElementById('btnContinue');
-
-      modal.focus(); // move focus into the modal for screen readers
-
-      // Toggle the Continue button when the acknowledgement is checked
-      chk.addEventListener('change', () => {
-        const enabled = chk.checked;
-        btn.disabled = !enabled;
-        btn.setAttribute('aria-disabled', String(!enabled));
-      });
-
-      // Hide modal and show main app content when user continues
-      btn.addEventListener('click', () => {
-        if (btn.disabled) return; // guard against accidental activation
-        modal.classList.add('hidden');
-        modal.setAttribute('aria-hidden','true');
-
-        app.classList.remove('hidden');
-        app.removeAttribute('aria-hidden');
-        app.focus(); // move focus to the main app region
-
-        // Optional routing hash update
-        location.hash = '#main';
-      });
-    }
 
     document.querySelectorAll('button[data-view]').forEach(btn=>{
       btn.addEventListener('click', ()=>{
@@ -257,8 +211,6 @@
     }).getDeveloperEmails();
 
     render('request');
-    // Initial modal blocks interaction until user acknowledges.
-    // `bindIntroModal` sets up its own event handlers on DOMContentLoaded.
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remove intro modal markup and script
- show main application immediately on load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a08490e38832293d52d79e60e595e