### PR TITLE
Use script lock for submissions to prevent null waitLock error

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -214,7 +214,10 @@ function nowIso_() {
 }
 
 function withLock_(fn) {
-  const lock = LockService.getDocumentLock();
+  // Standalone scripts don't have a document context, so `getDocumentLock`
+  // can return `null`. Use a script lock instead to avoid null dereference
+  // errors when submitting orders.
+  const lock = LockService.getScriptLock();
   lock.waitLock(30000);
   try {
     return fn();


### PR DESCRIPTION
## Summary
- prevent `waitLock` null errors when submitting orders by using a script lock instead of a document lock

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a16d063748322a0e06b357d31eeac