### PR TITLE
Fix submit request failing due to missing spreadsheet

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -135,8 +135,9 @@ function submitRequest(payload) {
   }
 
   return withScriptLock_(function () {
-    var ss = SpreadsheetApp.getActive();
-    var sh = ss.getSheetByName('Orders');
+    init_();
+    var ss = getSs_();
+    var sh = ss.getSheetByName(SHEET_ORDERS);
     if (!sh) throw new Error('Orders sheet not found.');
 
     var now = new Date();


### PR DESCRIPTION
## Summary
- Ensure submitRequest initializes spreadsheet and uses getSs_ to avoid null getSheetByName errors

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a2ae8cf448322884c8630ce1206d6