### PR TITLE
fix: show on-hold orders in approvals

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -99,7 +99,7 @@ function listApprovals_(email){
     return obj;
   });
   return orders
-    .filter(function(o){ return o.status === 'PENDING'; })
+    .filter(function(o){ return o.status === 'PENDING' || o.status === 'ON-HOLD'; })
     .sort(function(a,b){ return new Date(b.ts) - new Date(a.ts); });
 }
 


### PR DESCRIPTION
## Summary
- show ON-HOLD requests in approval queue

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a4e03d9208322a663dd0f58743bb9