### PR TITLE
fix: show newly submitted orders in lists

### DIFF
--- a/index.html
+++ b/index.html
@@ -176,11 +176,10 @@
     const payload = { lines: store.cart.lines.map(l => ({ description: l.description, qty: l.qty })) };
 
     google.script.run
-      .withSuccessHandler(ids => {
+      .withSuccessHandler(() => {
         store.cart.lines = [];
         renderCart();
         navigate('myRequests');
-        loadMyRequests();
         toast('Request sent for approval.');
         setSubmitting(false);
       })


### PR DESCRIPTION
## Summary
- ensure orders sheet headers are consistent
- return order records and flush when submitting
- show newest orders first in My Requests and Approvals
- simplify submit handler so navigation triggers refresh

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a54b7eec08322a5d60ce1818e378b