### PR TITLE
Remove authentication and LT email references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,8 +9,8 @@ This project is a lightweight supplies request system built on Google Apps Scrip
 Only the fields above are stored. Pricing and budget logic are intentionally omitted.
 
 ## Roles
-- Leadership Team users may submit requests and view their own history.
-- Admins manage pending approvals and the catalog. Static admins are `skhun@dublincleaners.com` and `ss.sku@protonmail.com` with optional additional addresses stored in script properties.
+- Any user may submit requests and view their own history.
+- Approval and catalog features are accessible to all users.
 
 ## Conventions
 - Keep code lean and mobile-first.

--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ A minimal supplies request and approval workflow built with Google Apps Script a
    ```
 2. Use [clasp](https://github.com/google/clasp) to push `Code.gs` and `index.html` to an Apps Script project tied to a Google Sheet.
 3. The script creates `Orders` and `Catalog` sheets if missing and seeds the catalog with default stock items.
-4. Update the allowlist emails in `Code.gs` as needed.
 
 ## Development
 Serve the HTML locally with Vite for quick iteration:

--- a/index.html
+++ b/index.html
@@ -31,8 +31,8 @@
   <nav id="nav">
     <button class="btn" data-view="request">Request</button>
     <button class="btn" data-view="myRequests">My Requests</button>
-    <button class="btn hidden" data-view="approvals" id="approveNav">Approvals</button>
-    <button class="btn hidden" data-view="catalog" id="catalogNav">Catalog</button>
+      <button class="btn" data-view="approvals" id="approveNav">Approvals</button>
+      <button class="btn" data-view="catalog" id="catalogNav">Catalog</button>
   </nav>
   <main id="main" class="p-2"></main>
   <script type="module">
@@ -44,17 +44,9 @@
 
   google.script.run.withSuccessHandler(s => {
     store.session = s;
-    if (!s.isLt) {
-      document.body.innerHTML = '<p class="p-2">Access denied</p>';
-      return;
-    }
-    if (s.isAdmin) {
-      document.getElementById('approveNav').classList.remove('hidden');
-      document.getElementById('catalogNav').classList.remove('hidden');
-    }
-    document.querySelectorAll('#nav button').forEach(b => b.addEventListener('click', () => navigate(b.dataset.view)));
-    renderRoute();
-  }).getSession();
+      document.querySelectorAll('#nav button').forEach(b => b.addEventListener('click', () => navigate(b.dataset.view)));
+      renderRoute();
+    }).getSession();
 
   function navigate(route) {
     store.route = route;


### PR DESCRIPTION
## Summary
- drop Leadership Team and admin allowlists, opening all features to any user
- simplify session handling and remove approver notifications tied to hard-coded emails
- expose approval and catalog navigation without access checks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a63d79ad88322bca4ba97bfafd4e3