### PR TITLE
Ensure listMyOrders uses session email

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -120,9 +120,9 @@ function submitOrder(payload) {
   return ids;
 }
 
-function listMyOrders(req) {
+function listMyOrders() {
   init_();
-  const email = (req && req.email) || Session.getActiveUser().getEmail();
+  const email = Session.getActiveUser().getEmail();
   const sheet = getSs_().getSheetByName(SHEET_ORDERS);
   const rows = sheet.getDataRange().getValues();
   const header = rows.shift();

--- a/index.html
+++ b/index.html
@@ -186,7 +186,7 @@
   function loadMyRequests() {
     google.script.run
       .withSuccessHandler(rows => renderMyRequests(rows))
-      .listMyOrders({ email: store.session.email });
+      .listMyOrders();
   }
 
   function renderMyRequests(rows) {


### PR DESCRIPTION
## Summary
- Disallow clients from specifying an arbitrary email when listing orders
- Update frontend to call listMyOrders without passing email

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6abe9a288322b1c3bda32a945ab6