### PR TITLE
fix: ensure loading indicator persists until supplies load

### DIFF
--- a/index.html
+++ b/index.html
@@ -52,12 +52,14 @@
   }
 
   setLoading(true);
-  google.script.run.withSuccessHandler(s => {
-    store.session = s;
+  google.script.run
+    .withSuccessHandler(s => {
+      store.session = s;
       document.querySelectorAll('#nav button').forEach(b => b.addEventListener('click', () => navigate(b.dataset.view)));
       renderRoute();
-      setLoading(false);
-    }).getSession();
+    })
+    .withFailureHandler(() => setLoading(false))
+    .getSession();
 
   function navigate(route) {
     store.route = route;


### PR DESCRIPTION
## Summary
- prevent early hiding of loading indicator by removing premature `setLoading(false)`
- add failure handler to session fetch so spinner clears if session load fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a6d0a21a48322a096790db14c7f93