### PR TITLE
fix: ensure submitted orders show in My Requests

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -120,9 +120,9 @@ function submitOrder(payload) {
   return ids;
 }
 
-function listMyOrders() {
+function listMyOrders(req) {
   init_();
-  const email = Session.getActiveUser().getEmail();
+  const email = (req && req.email) || getSession().email;
   const sheet = getSs_().getSheetByName(SHEET_ORDERS);
   const rows = sheet.getDataRange().getValues();
   const header = rows.shift();


### PR DESCRIPTION
## Summary
- filter orders by supplied email to load requests for the current user

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6f36af388322b1f1bb3c3b2a33e9