### PR TITLE
Improve header banner layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,8 @@
     body{font-family:Arial,sans-serif;margin:0;padding:0;}
     header{display:flex;align-items:center;justify-content:center;gap:0.5rem;padding:0.5rem;background:#1a73e8;color:#fff;}
     header img{height:125px;}
-    header h1{font-size:1.25rem;margin:0;}
+    .title h1{margin:0;font-size:1.5rem;font-weight:700;}
+    .title .subtitle{font-size:1rem;}
     nav{display:flex;gap:0.5rem;padding:0.5rem;background:#f5f5f5;flex-wrap:wrap;}
     nav button{flex:1 1 auto;}
     .hidden{display:none;}
@@ -29,7 +30,10 @@
 <body>
   <header>
     <img src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png" alt="Dublin Cleaners logo">
-    <h1>Supplies Order & Tracking</h1>
+    <div class="title">
+      <h1>Supplies</h1>
+      <div class="subtitle">Orders & Tracking</div>
+    </div>
   </header>
   <nav id="nav">
     <button class="btn" data-view="request">Request</button>


### PR DESCRIPTION
## Summary
- Bold "Supplies" heading on first line
- Add smaller "Orders & Tracking" subtitle beneath header

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a6f8566688322aa7ca916a5f11bba