### PR TITLE
Fix My Requests listing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -98,6 +98,7 @@ function setCatalogArchived(req) {
 }
 
 function submitOrder(payload) {
+  init_();
   const session = getSession();
   const sheet = getSs_().getSheetByName(SHEET_ORDERS);
   const ids = [];
@@ -126,9 +127,11 @@ function listMyOrders(req) {
   const sheet = getSs_().getSheetByName(SHEET_ORDERS);
   const rows = sheet.getDataRange().getValues();
   const header = rows.shift();
+  const idx = header.map(h => String(h).toLowerCase());
+  const reqIdx = idx.indexOf('requester');
   return rows
-    .filter(r => r[header.indexOf('requester')] === email)
-    .map(r => Object.fromEntries(r.map((v, i) => [header[i], v])));
+    .filter(r => reqIdx >= 0 && r[reqIdx] === email)
+    .map(r => Object.fromEntries(header.map((h, i) => [h, r[i]])));
 }
 
 function listPendingApprovals() {


### PR DESCRIPTION
## Summary
- Normalize header lookup when listing user orders so My Requests page shows submissions consistently
- Ensure order submissions initialize the spreadsheet before writing entries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a7164e0388322b1a6086221b8411f