### PR TITLE
fix: hide loading indicator after session load

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,6 +84,7 @@
       store.session = s;
       document.querySelectorAll('#nav button').forEach(b => b.addEventListener('click', () => navigate(b.dataset.view)));
       renderRoute();
+      setLoading(false);
     })
     .withFailureHandler(() => setLoading(false))
     .getSession();


### PR DESCRIPTION
## Summary
- Ensure page becomes interactive by hiding loading overlay after session initialization

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689a75d80e488322af6e5d331f9197e2