### PR TITLE
Avoid race when switching between request tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -235,7 +235,7 @@
       .withSuccessHandler(rows => {
         store.myRequests = rows;
         setLoading(false);
-        renderMyRequests();
+        if (store.route === 'myRequests') renderMyRequests();
       })
       .withFailureHandler(() => setLoading(false))
       .listMyOrders({ email: store.session.email });
@@ -258,7 +258,7 @@
       .withSuccessHandler(rows => {
         store.approvals = rows;
         setLoading(false);
-        renderApprovals();
+        if (store.route === 'approvals') renderApprovals();
       })
       .withFailureHandler(() => setLoading(false))
       .listPendingApprovals();


### PR DESCRIPTION
## Summary
- Render My Requests and Approvals tables only if the user is still viewing them after data loads

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689a834e074083229e6cf36e51e3d394