### PR TITLE
Handle missing request data in decideOrder

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -154,10 +154,13 @@ function listPendingApprovals() {
     .map(r => Object.fromEntries(keys.map((k, i) => [k, r[i]])));
 }
 
-function decideOrder(req) {
+function decideOrder(req = {}) {
   const session = getSession();
   return withLock_(() => {
     const { id, decision } = req;
+    if (!id || !decision) {
+      throw new Error('Missing id or decision');
+    }
     const sheet = getSs_().getSheetByName(SHEET_ORDERS);
     const values = sheet.getDataRange().getValues();
     const header = values.shift();


### PR DESCRIPTION
## Summary
- avoid TypeError when `decideOrder` receives no request object
- validate required `id` and `decision` fields before processing approvals

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b33c0df788322a6a5805342e0157c