### PR TITLE
handle missing req in addCatalogItem

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -71,9 +71,12 @@ function getCatalog(req) {
     .filter(r => includeArchived || r.archived !== true);
 }
 
-function addCatalogItem(req) {
+function addCatalogItem(req = {}) {
   return withLock_(() => {
     const { description, category } = req;
+    if (!description || !category) {
+      throw new Error('Missing description or category');
+    }
     const sheet = getSs_().getSheetByName(SHEET_CATALOG);
     const sku = uuid_();
     sheet.appendRow([sku, description, category, false]);


### PR DESCRIPTION
## Summary
- avoid TypeError when addCatalogItem called without arguments
- validate description and category before writing to catalog

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689b34afe8488322bed8597624adf302