### PR TITLE
Validate router action before CSRF check

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -212,6 +212,7 @@ function checkCsrf_(token) {
 function router(req) {
   req = req || {};
   const action = req.action;
+  if (!action) throw new Error('Unknown action');
   if (action !== 'getSession' && action !== 'listCatalog' && action !== 'listOrders' && action !== 'listBudgets') {
     checkCsrf_(req.csrf);
   }


### PR DESCRIPTION
## Summary
- Guard router to throw an explicit error when no action is provided before running CSRF validation.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689dc0ea751c8322ac670f5066a7a51d