### PR TITLE
Add per-view loading indicators

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,6 +19,12 @@ body.app-ready{overflow:auto;}
 .loading-subtitle{margin:0;font-size:1rem;color:inherit;letter-spacing:.08em;text-transform:uppercase;}
 .loading-bar{width:min(320px,80vw);height:8px;border-radius:999px;background:rgba(148,163,184,.4);overflow:hidden;box-shadow:0 12px 30px -20px rgba(15,23,42,.45);}
 .loading-progress{display:block;height:100%;width:100%;transform:scaleX(0);transform-origin:left;background:linear-gradient(90deg,var(--brand-primary),var(--brand-accent));transition:transform .8s cubic-bezier(.4,0,.2,1);}
+.section-loading{display:flex;align-items:center;gap:.75rem;margin:.5rem 0;padding:.75rem 1rem;border-radius:12px;background:rgba(26,115,232,.08);color:#1a73e8;font-weight:600;}
+.section-loading.hidden{display:none;}
+.section-loading-label{font-size:.875rem;}
+.section-loading-bar{flex:1;height:4px;border-radius:999px;background:rgba(26,115,232,.2);overflow:hidden;position:relative;}
+.section-loading-progress{display:block;width:100%;height:100%;background:linear-gradient(90deg,var(--brand-primary),var(--brand-accent));transform:translateX(-100%);animation:section-loading 1.4s ease-in-out infinite;}
+.section-loading.hidden .section-loading-progress{animation-play-state:paused;}
 .loading-overlay.loading-complete{background:radial-gradient(circle at top,var(--brand-light) 0%,rgba(241,245,249,0) 55%),var(--brand-secondary);color:#e0f2fe;}
 .loading-overlay.loading-complete .glitch{color:var(--brand-primary);-webkit-text-stroke:1px rgba(255,255,255,.5);}
 .loading-overlay.loading-complete .glitch::before{color:var(--brand-accent);mix-blend-mode:normal;}
@@ -26,6 +32,7 @@ body.app-ready{overflow:auto;}
 .loading-overlay.loading-complete .loading-subtitle{color:#f8fafc;}
 .loading-overlay.loading-complete .loading-progress{transform:scaleX(1);}
 body.app-ready .loading-overlay{opacity:0;visibility:hidden;pointer-events:none;}
+@keyframes section-loading{0%{transform:translateX(-100%);}50%{transform:translateX(0);}100%{transform:translateX(100%);}}
 @keyframes glitch-shift{0%{transform:translate(-1px,-1px);}20%{transform:translate(1px,1px);}40%{transform:translate(-3px,2px);}60%{transform:translate(2px,-2px);}80%{transform:translate(-1px,1px);}100%{transform:translate(1px,-1px);}}
 @keyframes glitch-shift-alt{0%{transform:translate(1px,1px);}20%{transform:translate(-1px,-1px);}40%{transform:translate(3px,-2px);}60%{transform:translate(-2px,2px);}80%{transform:translate(1px,-1px);}100%{transform:translate(-1px,1px);}}
 @media (prefers-reduced-motion:reduce){.glitch::before,.glitch::after{animation:none;}.loading-progress{transition-duration:.01ms;}}
@@ -171,6 +178,10 @@ const state = {
   rows: [],
   selection: new Set(),
   catalog: [],
+  loading: {
+    orders: false,
+    catalog: false
+  },
   dev: {
     allowed: INITIAL_DEV_ALLOWED,
     show: false,
@@ -199,6 +210,27 @@ let loaderFinalized = false;
 const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 const LOADER_COLOR_DELAY = prefersReducedMotion ? 120 : 820;
 const LOADER_FADE_DELAY = prefersReducedMotion ? 160 : 520;
+const SECTION_LOADERS = {
+  orders: () => document.getElementById('ordersLoading'),
+  catalog: () => document.getElementById('catalogLoading')
+};
+
+function updateSectionLoader(section){
+  const getter = SECTION_LOADERS[section];
+  if(typeof getter !== 'function') return;
+  const el = getter();
+  if(!el) return;
+  const active = !!(state.loading && state.loading[section]);
+  el.classList.toggle('hidden', !active);
+  el.setAttribute('aria-hidden', active ? 'false' : 'true');
+  el.setAttribute('aria-busy', active ? 'true' : 'false');
+}
+
+function setSectionLoading(section, isLoading){
+  if(!state.loading) state.loading = {};
+  state.loading[section] = !!isLoading;
+  updateSectionLoader(section);
+}
 
 function scheduleWork(fn,{priority='normal',timeout=600}={}){
   if(typeof fn !== 'function') return;
@@ -498,6 +530,13 @@ function renderRequest(app){
       }
       renderCatalogList('catalogPreview',{limit:6});
       updateItemPreview();
+    }).catch(err=>{
+      console.error(err);
+      const previewWrap = document.getElementById('catalogPreview');
+      if(previewWrap){
+        previewWrap.innerHTML = '<p class="footnote">Catalog preview unavailable.</p>';
+      }
+      toast('Unable to load catalog preview.');
     });
   };
   if('requestIdleCallback' in window){
@@ -542,6 +581,10 @@ function renderAll(app){
             <button id="dn" class="ghost" type="button">Deny</button>
             <button id="oh" class="ghost" type="button">On-Hold</button>
           </div>
+        </div>
+        <div id="ordersLoading" class="section-loading hidden" role="status" aria-live="polite" aria-hidden="true" aria-busy="false">
+          <span class="section-loading-label">Loading requests…</span>
+          <div class="section-loading-bar" aria-hidden="true"><span class="section-loading-progress"></span></div>
         </div>
         <div class="table-wrapper">
           <table id="list">
@@ -605,6 +648,7 @@ function renderAll(app){
       </section>
     </section>
   `;
+  updateSectionLoader('orders');
   const st = ['PENDING','APPROVED','DENIED','ON-HOLD'];
   const chipsDiv = app.querySelector('#statusChips');
   st.forEach(s=>{
@@ -651,7 +695,15 @@ function renderAll(app){
     setupProofPanel(app);
   }
   loadOrders();
-  loadCatalog().then(()=>renderCatalogList('catalogInline',{limit:6}));
+  loadCatalog().then(()=>renderCatalogList('catalogInline',{limit:6}))
+    .catch(err=>{
+      console.error(err);
+      const inline = document.getElementById('catalogInline');
+      if(inline){
+        inline.innerHTML = '<p class="footnote">Catalog snapshot unavailable.</p>';
+      }
+      toast('Unable to load catalog snapshot.');
+    });
 }
 
 function renderCatalog(app){
@@ -663,7 +715,11 @@ function renderCatalog(app){
           <h2 class="panel-title">All items</h2>
           <button class="link" type="button" data-route="request">Submit a request</button>
         </div>
-        <div id="catalogFull"><p class="footnote">Loading catalog...</p></div>
+        <div id="catalogLoading" class="section-loading hidden" role="status" aria-live="polite" aria-hidden="true" aria-busy="false">
+          <span class="section-loading-label">Loading catalog…</span>
+          <div class="section-loading-bar" aria-hidden="true"><span class="section-loading-progress"></span></div>
+        </div>
+        <div id="catalogFull"></div>
       </section>
       ${CAN_MANAGE_THUMBS ? `
       <section class="panel stack" id="thumbPanel">
@@ -698,16 +754,27 @@ function renderCatalog(app){
       ` : ''}
     </section>
   `;
+  updateSectionLoader('catalog');
   app.querySelector('[data-route="request"]').onclick = ()=>route('request');
   if(CAN_MANAGE_THUMBS){
     setupThumbPanel(app);
   }
   const scheduleCatalogLoad = () => {
+    setSectionLoading('catalog', true);
     loadCatalog().then(()=>{
       renderCatalogList('catalogFull');
       if(CAN_MANAGE_THUMBS){
         populateThumbOptions();
       }
+      setSectionLoading('catalog', false);
+    }).catch(err=>{
+      const message = err && err.message ? err.message : 'Unable to load catalog.';
+      toast(message);
+      const target = document.getElementById('catalogFull');
+      if(target){
+        target.innerHTML = `<p class="footnote">${message}</p>`;
+      }
+      setSectionLoading('catalog', false);
     });
   };
   if('requestIdleCallback' in window){
@@ -786,9 +853,11 @@ function renderCatalogList(targetId,{limit}={}){
 }
 
 function loadCatalog(force=false){
-  if(!force && state.catalog.length) return Promise.resolve();
-  return new Promise(res=>{
-    google.script.run.withSuccessHandler(rows=>{state.catalog = rows;res();}).router({action:'listCatalog'});
+  if(!force && state.catalog.length) return Promise.resolve(state.catalog);
+  return new Promise((resolve,reject)=>{
+    google.script.run.withSuccessHandler(rows=>{state.catalog = rows;resolve(rows);})
+      .withFailureHandler(err=>reject(err))
+      .router({action:'listCatalog'});
   });
 }
 
@@ -832,6 +901,7 @@ function updateFilters(){
 }
 
 function loadOrders(){
+  setSectionLoading('orders', true);
   google.script.run.withSuccessHandler(rows=>{
     state.rows=rows;
     renderRows();
@@ -841,6 +911,11 @@ function loadOrders(){
         proofPanelCtx.orderLabel.textContent = `${current.item} • ${current.ts}`;
       }
     }
+    setSectionLoading('orders', false);
+  }).withFailureHandler(err=>{
+    setSectionLoading('orders', false);
+    const message = err && err.message ? err.message : 'Unable to load requests.';
+    toast(message);
   })
     .router({action:'listOrders',filter:state.filters});
 }
@@ -1122,8 +1197,15 @@ function saveThumbnail(){
   if(thumbPanelCtx.saveButton) thumbPanelCtx.saveButton.disabled = true;
   google.script.run.withSuccessHandler(()=>{
     toast('Thumbnail updated');
+    const catalogVisible = !!document.getElementById('catalogFull');
+    if(catalogVisible) setSectionLoading('catalog', true);
     loadCatalog(true).then(()=>{
       refreshCatalogViews();
+      if(catalogVisible) setSectionLoading('catalog', false);
+    }).catch(err=>{
+      console.error(err);
+      if(catalogVisible) setSectionLoading('catalog', false);
+      toast(err && err.message ? err.message : 'Unable to refresh catalog.');
     });
   }).withFailureHandler(err=>{
     toast(err.message);


### PR DESCRIPTION
## Summary
- add reusable loading bar styles and helper utilities to track section fetch state
- surface progress bars for All Requests and Catalog views while data loads and improve related error handling
- refresh catalog thumbnail updates through the new loader flow to keep UI feedback consistent

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68d43ac5980083229e53ef4af3721145