### PR TITLE
Revert dynamic page loading changes

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,6 +7,28 @@
 :root{--brand-primary:#1a73e8;--brand-accent:#39bdf8;--brand-secondary:#0b1120;--brand-light:#f1f5f9;}
 *,*::before,*::after{box-sizing:border-box;}
 body{font-family:Arial,sans-serif;margin:0;background:#f5f7fb;color:#1f2933;min-height:100vh;}
+body.is-loading{overflow:hidden;}
+body.app-ready{overflow:auto;}
+.loading-overlay{position:fixed;inset:0;display:flex;align-items:center;justify-content:center;background:#e5e7eb;color:#94a3b8;z-index:120;transition:background .6s ease,color .4s ease,opacity .45s ease,visibility .45s ease;pointer-events:auto;}
+.loading-overlay .loading-inner{display:flex;flex-direction:column;align-items:center;gap:1.25rem;padding:2rem;text-align:center;}
+.glitch{position:relative;font-size:clamp(2.75rem,7vw,5rem);font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:transparent;-webkit-text-stroke:2px #64748b;filter:drop-shadow(0 20px 40px rgba(15,23,42,.25));}
+.glitch span{display:block;color:currentColor;-webkit-text-stroke:0;}
+.glitch::before,.glitch::after{content:attr(data-text);position:absolute;left:0;top:0;width:100%;color:currentColor;opacity:.75;mix-blend-mode:screen;}
+.glitch::before{transform:translate(-2px,-2px);clip-path:polygon(0 2%,100% 0,100% 48%,0 54%);animation:glitch-shift 2.1s infinite ease-in-out alternate;}
+.glitch::after{transform:translate(2px,2px);clip-path:polygon(0 52%,100% 48%,100% 100%,0 98%);animation:glitch-shift-alt 1.8s infinite ease-in-out alternate-reverse;}
+.loading-subtitle{margin:0;font-size:1rem;color:inherit;letter-spacing:.08em;text-transform:uppercase;}
+.loading-bar{width:min(320px,80vw);height:8px;border-radius:999px;background:rgba(148,163,184,.4);overflow:hidden;box-shadow:0 12px 30px -20px rgba(15,23,42,.45);}
+.loading-progress{display:block;height:100%;width:100%;transform:scaleX(0);transform-origin:left;background:linear-gradient(90deg,var(--brand-primary),var(--brand-accent));transition:transform .8s cubic-bezier(.4,0,.2,1);}
+.loading-overlay.loading-complete{background:radial-gradient(circle at top,var(--brand-light) 0%,rgba(241,245,249,0) 55%),var(--brand-secondary);color:#e0f2fe;}
+.loading-overlay.loading-complete .glitch{color:var(--brand-primary);-webkit-text-stroke:1px rgba(255,255,255,.5);}
+.loading-overlay.loading-complete .glitch::before{color:var(--brand-accent);mix-blend-mode:normal;}
+.loading-overlay.loading-complete .glitch::after{color:#c4f1ff;mix-blend-mode:normal;}
+.loading-overlay.loading-complete .loading-subtitle{color:#f8fafc;}
+.loading-overlay.loading-complete .loading-progress{transform:scaleX(1);}
+body.app-ready .loading-overlay{opacity:0;visibility:hidden;pointer-events:none;}
+@keyframes glitch-shift{0%{transform:translate(-1px,-1px);}20%{transform:translate(1px,1px);}40%{transform:translate(-3px,2px);}60%{transform:translate(2px,-2px);}80%{transform:translate(-1px,1px);}100%{transform:translate(1px,-1px);}}
+@keyframes glitch-shift-alt{0%{transform:translate(1px,1px);}20%{transform:translate(-1px,-1px);}40%{transform:translate(3px,-2px);}60%{transform:translate(-2px,2px);}80%{transform:translate(1px,-1px);}100%{transform:translate(-1px,1px);}}
+@media (prefers-reduced-motion:reduce){.glitch::before,.glitch::after{animation:none;}.loading-progress{transition-duration:.01ms;}}
 .app-header{display:flex;flex-direction:column;align-items:center;justify-content:center;padding:1rem 1rem .75rem;background:#fff;box-shadow:0 1px 0 rgba(15,23,42,.08);gap:.5rem;text-align:center;}
 .app-logo{height:80px;object-fit:contain;}
 @media (min-width:640px){.app-logo{height:96px;}}
@@ -113,7 +135,14 @@ tr:nth-child(even){background:#f8fafc;}
 .preview.hidden{display:none;}
 </style>
 </head>
-<body>
+<body class="is-loading">
+<div id="loadingOverlay" class="loading-overlay" role="status" aria-live="polite">
+  <div class="loading-inner">
+    <div class="glitch" data-text="Dublin Cleaners"><span>Dublin</span><span>Cleaners</span></div>
+    <p class="loading-subtitle">Booting up supplies tracker…</p>
+    <div class="loading-bar" aria-hidden="true"><span class="loading-progress"></span></div>
+  </div>
+</div>
 <header class="app-header">
 <img src="https://www.dublincleaners.com/wp-content/uploads/2025/06/LogosHQ.png" alt="Dublin Cleaners logo" class="app-logo">
 </header>
@@ -142,10 +171,6 @@ const state = {
   rows: [],
   selection: new Set(),
   catalog: [],
-  loading: {
-    orders: false,
-    catalog: false
-  },
   dev: {
     allowed: INITIAL_DEV_ALLOWED,
     show: false,
@@ -169,6 +194,12 @@ const CAN_UPLOAD_IMAGES = ['developer','super_admin'].includes(SESSION.role);
 let proofPanelCtx = null;
 let thumbPanelCtx = null;
 let devModalReady = false;
+let initialRouteRendered = false;
+let loaderFinalized = false;
+const prefersReducedMotion = typeof window !== 'undefined' && window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+const LOADER_COLOR_DELAY = prefersReducedMotion ? 120 : 820;
+const LOADER_FADE_DELAY = prefersReducedMotion ? 160 : 520;
+
 function scheduleWork(fn,{priority='normal',timeout=600}={}){
   if(typeof fn !== 'function') return;
   if(priority === 'high'){
@@ -180,6 +211,46 @@ function scheduleWork(fn,{priority='normal',timeout=600}={}){
   }else{
     const delay = priority === 'low' ? 140 : 40;
     setTimeout(fn,delay);
+  }
+}
+
+function markLoaderComplete(){
+  if(loaderFinalized){
+    return;
+  }
+  loaderFinalized = true;
+  const overlay = document.getElementById('loadingOverlay');
+  const cleanup = ()=>{
+    document.body.classList.remove('is-loading');
+    document.body.classList.add('app-ready');
+    if(overlay){
+      const removeOverlay = ()=>{
+        if(overlay.parentNode){
+          overlay.parentNode.removeChild(overlay);
+        }
+      };
+      overlay.addEventListener('transitionend',function handler(e){
+        if(e.propertyName === 'opacity'){
+          overlay.removeEventListener('transitionend',handler);
+          removeOverlay();
+        }
+      });
+      if(prefersReducedMotion){
+        removeOverlay();
+      }else{
+        setTimeout(removeOverlay,LOADER_FADE_DELAY);
+      }
+    }
+  };
+  if(overlay){
+    overlay.classList.add('loading-complete');
+    if(prefersReducedMotion){
+      cleanup();
+    }else{
+      setTimeout(cleanup,LOADER_COLOR_DELAY);
+    }
+  }else{
+    cleanup();
   }
 }
 
@@ -258,6 +329,10 @@ function route(r){
   if(r === 'request') renderRequest(app);
   else if(r === 'all') renderAll(app);
   else if(r === 'catalog') renderCatalog(app);
+  if(!initialRouteRendered){
+    initialRouteRendered = true;
+    requestAnimationFrame(()=>requestAnimationFrame(markLoaderComplete));
+  }
 }
 
 function viewHeader(title, subtitle=''){
@@ -423,13 +498,6 @@ function renderRequest(app){
       }
       renderCatalogList('catalogPreview',{limit:6});
       updateItemPreview();
-    }).catch(err=>{
-      console.error(err);
-      const previewWrap = document.getElementById('catalogPreview');
-      if(previewWrap){
-        previewWrap.innerHTML = '<p class="footnote">Catalog preview unavailable.</p>';
-      }
-      toast('Unable to load catalog preview.');
     });
   };
   if('requestIdleCallback' in window){
@@ -474,10 +542,6 @@ function renderAll(app){
             <button id="dn" class="ghost" type="button">Deny</button>
             <button id="oh" class="ghost" type="button">On-Hold</button>
           </div>
-        </div>
-        <div id="ordersLoading" class="section-loading hidden" role="status" aria-live="polite" aria-hidden="true" aria-busy="false">
-          <span class="section-loading-label">Loading requests…</span>
-          <div class="section-loading-bar" aria-hidden="true"><span class="section-loading-progress"></span></div>
         </div>
         <div class="table-wrapper">
           <table id="list">
@@ -541,7 +605,6 @@ function renderAll(app){
       </section>
     </section>
   `;
-  updateSectionLoader('orders');
   const st = ['PENDING','APPROVED','DENIED','ON-HOLD'];
   const chipsDiv = app.querySelector('#statusChips');
   st.forEach(s=>{
@@ -588,15 +651,7 @@ function renderAll(app){
     setupProofPanel(app);
   }
   loadOrders();
-  loadCatalog().then(()=>renderCatalogList('catalogInline',{limit:6}))
-    .catch(err=>{
-      console.error(err);
-      const inline = document.getElementById('catalogInline');
-      if(inline){
-        inline.innerHTML = '<p class="footnote">Catalog snapshot unavailable.</p>';
-      }
-      toast('Unable to load catalog snapshot.');
-    });
+  loadCatalog().then(()=>renderCatalogList('catalogInline',{limit:6}));
 }
 
 function renderCatalog(app){
@@ -608,11 +663,7 @@ function renderCatalog(app){
           <h2 class="panel-title">All items</h2>
           <button class="link" type="button" data-route="request">Submit a request</button>
         </div>
-        <div id="catalogLoading" class="section-loading hidden" role="status" aria-live="polite" aria-hidden="true" aria-busy="false">
-          <span class="section-loading-label">Loading catalog…</span>
-          <div class="section-loading-bar" aria-hidden="true"><span class="section-loading-progress"></span></div>
-        </div>
-        <div id="catalogFull"></div>
+        <div id="catalogFull"><p class="footnote">Loading catalog...</p></div>
       </section>
       ${CAN_MANAGE_THUMBS ? `
       <section class="panel stack" id="thumbPanel">
@@ -647,27 +698,16 @@ function renderCatalog(app){
       ` : ''}
     </section>
   `;
-  updateSectionLoader('catalog');
   app.querySelector('[data-route="request"]').onclick = ()=>route('request');
   if(CAN_MANAGE_THUMBS){
     setupThumbPanel(app);
   }
   const scheduleCatalogLoad = () => {
-    setSectionLoading('catalog', true);
     loadCatalog().then(()=>{
       renderCatalogList('catalogFull');
       if(CAN_MANAGE_THUMBS){
         populateThumbOptions();
       }
-      setSectionLoading('catalog', false);
-    }).catch(err=>{
-      const message = err && err.message ? err.message : 'Unable to load catalog.';
-      toast(message);
-      const target = document.getElementById('catalogFull');
-      if(target){
-        target.innerHTML = `<p class="footnote">${message}</p>`;
-      }
-      setSectionLoading('catalog', false);
     });
   };
   if('requestIdleCallback' in window){
@@ -746,11 +786,9 @@ function renderCatalogList(targetId,{limit}={}){
 }
 
 function loadCatalog(force=false){
-  if(!force && state.catalog.length) return Promise.resolve(state.catalog);
-  return new Promise((resolve,reject)=>{
-    google.script.run.withSuccessHandler(rows=>{state.catalog = rows;resolve(rows);})
-      .withFailureHandler(err=>reject(err))
-      .router({action:'listCatalog'});
+  if(!force && state.catalog.length) return Promise.resolve();
+  return new Promise(res=>{
+    google.script.run.withSuccessHandler(rows=>{state.catalog = rows;res();}).router({action:'listCatalog'});
   });
 }
 
@@ -794,7 +832,6 @@ function updateFilters(){
 }
 
 function loadOrders(){
-  setSectionLoading('orders', true);
   google.script.run.withSuccessHandler(rows=>{
     state.rows=rows;
     renderRows();
@@ -804,11 +841,6 @@ function loadOrders(){
         proofPanelCtx.orderLabel.textContent = `${current.item} • ${current.ts}`;
       }
     }
-    setSectionLoading('orders', false);
-  }).withFailureHandler(err=>{
-    setSectionLoading('orders', false);
-    const message = err && err.message ? err.message : 'Unable to load requests.';
-    toast(message);
   })
     .router({action:'listOrders',filter:state.filters});
 }
@@ -1090,15 +1122,8 @@ function saveThumbnail(){
   if(thumbPanelCtx.saveButton) thumbPanelCtx.saveButton.disabled = true;
   google.script.run.withSuccessHandler(()=>{
     toast('Thumbnail updated');
-    const catalogVisible = !!document.getElementById('catalogFull');
-    if(catalogVisible) setSectionLoading('catalog', true);
     loadCatalog(true).then(()=>{
       refreshCatalogViews();
-      if(catalogVisible) setSectionLoading('catalog', false);
-    }).catch(err=>{
-      console.error(err);
-      if(catalogVisible) setSectionLoading('catalog', false);
-      toast(err && err.message ? err.message : 'Unable to refresh catalog.');
     });
   }).withFailureHandler(err=>{
     toast(err.message);


### PR DESCRIPTION
## Summary
- restore the legacy boot overlay and initialization flow so the app waits for the first route render before dismissing the loader
- remove the per-view progress spinner hooks that were added with the dynamic page loading work, returning to the previous synchronous rendering path

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d43eb5a34483228e709723a6d7566e