### PR TITLE
Add option to reselect catalog item

### DIFF
--- a/index.html
+++ b/index.html
@@ -362,6 +362,7 @@ function renderRequest(app){
               <div class="catalog-item-text">
                 <strong id="itemPreviewLabel"></strong>
                 <button id="itemPreviewOpen" type="button" class="link">Open full image</button>
+                <button id="itemPreviewChange" type="button" class="link">Choose another item</button>
               </div>
             </div>
           </label>
@@ -423,6 +424,7 @@ function renderRequest(app){
   }
   const previewLabel = app.querySelector('#itemPreviewLabel');
   const previewOpen = app.querySelector('#itemPreviewOpen');
+  const previewChange = app.querySelector('#itemPreviewChange');
   let previewSrc = '';
   function hideItemPreview(){
     if(preview){
@@ -490,6 +492,16 @@ function renderRequest(app){
   }
   if(previewOpen){
     previewOpen.onclick = () => { if(previewSrc) window.open(previewSrc, '_blank'); };
+  }
+  if(previewChange){
+    previewChange.onclick = () => {
+      hideItemPreview();
+      if(itemInput){
+        itemInput.value = '';
+        itemInput.focus();
+        itemInput.dispatchEvent(new Event('input'));
+      }
+    };
   }
   app.querySelectorAll('[data-route="catalog"]').forEach(btn=>btn.onclick=()=>route('catalog'));
   const schedulePreviewLoad = () => {


### PR DESCRIPTION
## Summary
- add a "Choose another item" control to the catalog item preview so requesters can clear their current selection
- wire the control to hide the preview, clear the item field, and focus it for easy reselection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d451e9d28c8322958b466805a7d736