### PR TITLE
Enable reopening catalog picker after selection

### DIFF
--- a/index.html
+++ b/index.html
@@ -457,9 +457,28 @@ function renderRequest(app){
       hideItemPreview();
     }
   }
+  function openItemPicker(){
+    if(!itemInput) return;
+    if(typeof itemInput.showPicker === 'function'){
+      try{
+        itemInput.showPicker();
+        return;
+      }catch(err){
+        console.warn('showPicker failed', err);
+      }
+    }
+    if(itemInput.value){
+      itemInput.select();
+    }
+  }
   if(itemInput){
     itemInput.addEventListener('input', updateItemPreview);
     itemInput.addEventListener('change', updateItemPreview);
+    itemInput.addEventListener('click', openItemPicker);
+    itemInput.addEventListener('focus', openItemPicker);
+    itemInput.addEventListener('keydown', evt=>{
+      if(evt.key === 'ArrowDown') openItemPicker();
+    });
   }
   function toggleGroupVisibility(group, hidden){
     if(!group) return;
@@ -500,6 +519,7 @@ function renderRequest(app){
         itemInput.value = '';
         itemInput.focus();
         itemInput.dispatchEvent(new Event('input'));
+        openItemPicker();
       }
     };
   }


### PR DESCRIPTION
## Summary
- add an `openItemPicker` helper so the catalog datalist can be reopened after a selection
- trigger the picker on click/focus/arrow down and after clearing via the preview change button for easier reselection

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d4572058bc83229f7d570fe4cf0955