### PR TITLE
Guard item reselection against secondary clicks

### DIFF
--- a/index.html
+++ b/index.html
@@ -464,8 +464,16 @@ function renderRequest(app){
     }
     itemBrowseRestore = null;
   }
-  function beginItemReselection(){
+  function beginItemReselection(evt){
     if(!itemInput) return;
+    if(evt){
+      const pointerType = typeof evt.pointerType === 'string' ? evt.pointerType : '';
+      const isTouchLike = pointerType === 'touch' || pointerType === 'pen';
+      if(!isTouchLike){
+        if(typeof evt.button === 'number' && evt.button !== 0) return;
+        if(evt.ctrlKey) return;
+      }
+    }
     const currentValue = itemInput.value || '';
     if(!currentValue.trim() || itemBrowseRestore) return;
     const currentMatch = state.catalog.find(row => (row.description || '').toLowerCase() === currentValue.toLowerCase().trim());


### PR DESCRIPTION
## Summary
- ignore non-primary pointer interactions when preparing the catalog input for reselection
- prevent context-menu/right-click gestures from clearing the existing selection before the user chooses another item

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d459cab4ac83228cbe1d4b7b1b7377