### PR TITLE
Gracefully handle cross-origin showPicker failures

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,15 +485,24 @@ function renderRequest(app){
       openItemPicker();
     });
   }
+  let itemPickerUnavailable = false;
+  let itemPickerWarned = false;
   function openItemPicker(){
     if(!itemInput) return;
-    if(typeof itemInput.showPicker === 'function'){
+    if(!itemPickerUnavailable && typeof itemInput.showPicker === 'function'){
       try{
         itemInput.showPicker();
         return;
       }catch(err){
-        console.warn('showPicker failed', err);
+        itemPickerUnavailable = true;
+        if(!itemPickerWarned){
+          itemPickerWarned = true;
+          console.warn('showPicker failed', err);
+        }
       }
+    }
+    if(document.activeElement !== itemInput){
+      itemInput.focus();
     }
     if(itemInput.value){
       itemInput.select();


### PR DESCRIPTION
## Summary
- skip repeated calls to `HTMLInputElement.showPicker()` once it throws in cross-origin contexts
- provide a keyboard-friendly fallback by focusing/selecting the input when the picker cannot open

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d45bdbce6c83229f1153e0fd106883