### PR TITLE
Fix catalog picker requiring double click

### DIFF
--- a/index.html
+++ b/index.html
@@ -478,12 +478,42 @@ function renderRequest(app){
     if(!currentValue.trim() || itemBrowseRestore) return;
     const currentMatch = state.catalog.find(row => (row.description || '').toLowerCase() === currentValue.toLowerCase().trim());
     itemBrowseRestore = { value: currentValue, match: currentMatch };
-    requestAnimationFrame(()=>{
-      if(!itemBrowseRestore || itemInput.value !== currentValue) return;
+    const pointerId = evt && typeof evt.pointerId === 'number' ? evt.pointerId : null;
+
+    function cleanup(){
+      window.removeEventListener('pointerup', handlePointerUp);
+      window.removeEventListener('pointercancel', handleCancel);
+      window.removeEventListener('blur', handleCancel);
+    }
+
+    function handleCancel(){
+      cleanup();
+      if(itemBrowseRestore && itemBrowseRestore.value === currentValue){
+        itemBrowseRestore = null;
+      }
+    }
+
+    function handlePointerUp(upEvt){
+      if(pointerId !== null && typeof upEvt.pointerId === 'number' && upEvt.pointerId !== pointerId){
+        return;
+      }
+      cleanup();
+      if(upEvt.target !== itemInput){
+        if(itemBrowseRestore && itemBrowseRestore.value === currentValue){
+          itemBrowseRestore = null;
+        }
+        return;
+      }
+      if(!itemBrowseRestore || itemInput.value !== currentValue){
+        return;
+      }
       itemInput.value = '';
       itemInput.dispatchEvent(new Event('input'));
-      openItemPicker();
-    });
+    }
+
+    window.addEventListener('pointerup', handlePointerUp);
+    window.addEventListener('pointercancel', handleCancel);
+    window.addEventListener('blur', handleCancel);
   }
   let itemPickerUnavailable = false;
   let itemPickerWarned = false;


### PR DESCRIPTION
## Summary
- delay catalog item reselection clearing until pointer release so the datalist opens on the first click
- add cleanup handlers for pointer cancel/blur events to avoid leaving the previous value cleared unexpectedly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d45d6ab834832285e1d4c0e55cb030