### PR TITLE
Ensure approvers inherit decision capabilities

### DIFF
--- a/index.html
+++ b/index.html
@@ -234,16 +234,23 @@ function currentRole(){
 }
 
 function sessionCapabilities(){
-  if(!state.session || !state.session.capabilities){
-    return { ...DEFAULT_CAPABILITIES };
-  }
-  const caps = state.session.capabilities;
-  return {
+  const caps = state.session && state.session.capabilities ? state.session.capabilities : DEFAULT_CAPABILITIES;
+  const normalized = {
     canDecide: !!caps.canDecide,
     canManageProof: !!caps.canManageProof,
     canManageThumbs: !!caps.canManageThumbs,
     canUploadImages: !!caps.canUploadImages
   };
+  const role = currentRole();
+  if(['approver','developer','super_admin'].includes(role)){
+    normalized.canDecide = true;
+    normalized.canManageProof = true;
+  }
+  if(['developer','super_admin'].includes(role)){
+    normalized.canManageThumbs = true;
+    normalized.canUploadImages = true;
+  }
+  return normalized;
 }
 
 function canDecideRequests(){


### PR DESCRIPTION
## Summary
- ensure session capability normalization grants approvers decision access even when capability flags are unset
- keep proof and catalog management rights aligned with role-based permissions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d6894516a88322bc085679e6a23511