### PR TITLE
Prevent hover accent on request cards

### DIFF
--- a/index.html
+++ b/index.html
@@ -267,6 +267,12 @@
       background: var(--accent-strong);
     }
 
+    button.card-toggle:not([disabled]):hover,
+    button.card-toggle:not([disabled]):focus-visible {
+      background: none;
+      color: inherit;
+    }
+
     button.secondary {
       background: var(--surface-alt);
       color: var(--accent);


### PR DESCRIPTION
## Summary
- stop card toggle headers from inheriting the global blue hover styling
- keep the text color neutral when the card toggle receives hover or focus states

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7b976ccd083228cbdddc21594d8fb