### PR TITLE
Add location selection to supplies request form

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -13,8 +13,9 @@ const LOCATION_OPTIONS = ['Plant', 'Short North', 'South Dublin', 'Muirfield', '
 const REQUEST_TYPES = {
   supplies: {
     sheetName: 'SuppliesRequests',
-    headers: ['id', 'ts', 'requester', 'description', 'qty', 'notes', 'status', 'approver'],
+    headers: ['id', 'ts', 'requester', 'description', 'qty', 'location', 'notes', 'status', 'approver'],
     normalize(request) {
+      const location = normalizeLocation_(request && request.location);
       const description = sanitizeString_(request && request.description);
       if (!description) {
         throw new Error('Description is required.');
@@ -24,13 +25,16 @@ const REQUEST_TYPES = {
         throw new Error('Quantity must be at least 1.');
       }
       const notes = sanitizeString_(request && request.notes);
-      return { description, qty, notes };
+      return { description, qty, location, notes };
     },
     buildSummary(fields) {
       return fields.description || 'Supplies request';
     },
     buildDetails(fields) {
       const details = [];
+      if (fields.location) {
+        details.push(`Location: ${fields.location}`);
+      }
       if (fields.qty) {
         details.push(`Quantity: ${fields.qty}`);
       }

--- a/index.html
+++ b/index.html
@@ -529,6 +529,19 @@
               <select id="catalogSelect" name="catalogSku" required></select>
             </label>
             <label>
+              <span>Location</span>
+              <select id="suppliesLocation" name="location" required>
+                <option value="">Select a location</option>
+                <option value="Plant">Plant</option>
+                <option value="Short North">Short North</option>
+                <option value="South Dublin">South Dublin</option>
+                <option value="Muirfield">Muirfield</option>
+                <option value="Morse Rd.">Morse Rd.</option>
+                <option value="Granville">Granville</option>
+                <option value="Newark">Newark</option>
+              </select>
+            </label>
+            <label>
               <span>Quantity</span>
               <input id="suppliesQty" name="qty" type="number" min="1" step="1" required>
             </label>
@@ -719,7 +732,7 @@
       const persistTimers = {};
       let warmScheduled = false;
       const FORM_TEMPLATES = {
-        supplies: { description: '', qty: 1, notes: '', catalogSku: '' },
+        supplies: { description: '', qty: 1, notes: '', catalogSku: '', location: '' },
         it: { location: '', issue: '', device: '', urgency: 'normal', details: '' },
         maintenance: { location: '', issue: '', urgency: 'normal', accessNotes: '' }
       };
@@ -779,6 +792,7 @@
         toast: document.getElementById('toast'),
         supplies: {
           form: document.getElementById('suppliesForm'),
+          location: document.getElementById('suppliesLocation'),
           qty: document.getElementById('suppliesQty'),
           notes: document.getElementById('suppliesNotes'),
           submit: document.getElementById('suppliesSubmitButton'),
@@ -925,6 +939,10 @@
         dom.supplies.form.addEventListener('submit', evt => handleSubmit(evt, 'supplies'));
         dom.supplies.reset.addEventListener('click', () => {
           resetForm('supplies');
+        });
+        dom.supplies.location.addEventListener('change', () => {
+          setFormState('supplies', { location: dom.supplies.location.value });
+          persistForm('supplies');
         });
         dom.supplies.qty.addEventListener('input', () => {
           const qty = Number(dom.supplies.qty.value);
@@ -1098,6 +1116,9 @@
       function validateForm(type, formState) {
         switch (type) {
           case 'supplies':
+            if (!formState.location || !formState.location.trim()) {
+              return 'Location is required.';
+            }
             if (!formState.description || !formState.description.trim()) {
               return 'Please pick an item before submitting.';
             }
@@ -1139,6 +1160,7 @@
         const formState = state.forms[type];
         if (type === 'supplies') {
           dom.supplies.catalogSelect.value = formState.catalogSku || '';
+          dom.supplies.location.value = formState.location || '';
           dom.supplies.qty.value = formState.qty || 1;
           dom.supplies.notes.value = formState.notes || '';
         } else if (type === 'it') {
@@ -1569,6 +1591,7 @@
       function disableForm(type, disabled) {
         if (type === 'supplies') {
           dom.supplies.submit.disabled = disabled;
+          dom.supplies.location.disabled = disabled;
           dom.supplies.qty.disabled = disabled;
           dom.supplies.notes.disabled = disabled;
           dom.supplies.catalogSelect.disabled = disabled;


### PR DESCRIPTION
## Summary
- add a location dropdown to the supplies request form with the same options as other request types
- persist, validate, and disable the new field across the client-side form workflow
- capture the selected location when storing supplies requests and include it in request details

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7bd842b408322b3fb10e6f0d3cd20