### PR TITLE
Fix tab activation crash when switching sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -921,10 +921,6 @@
         dom.panels.forEach(panel => {
           panel.classList.toggle('active', panel.getAttribute('data-tab-panel') === type);
         });
-        if (!state.openCards[type] && CARD_ORDER[type] && CARD_ORDER[type].length) {
-          state.openCards[type] = CARD_ORDER[type][0];
-        }
-        syncCardStack();
         ensureRequestsLoaded(type);
         scheduleWarmCache();
       }


### PR DESCRIPTION
## Summary
- remove references to undefined card stack helpers during tab activation
- allow request lists and catalog data to load again by preventing the runtime ReferenceError

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7c0b912cc8322bd86fbe33e150ec0