### PR TITLE
Adjust supplies actions buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,9 +355,13 @@
       margin-top: 0.5rem;
     }
 
+    .supplies-actions .inline-buttons {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    }
+
     .supplies-actions .inline-buttons button {
-      flex: 1 1 30%;
-      min-width: 0;
+      width: 100%;
     }
 
     .eta-field {
@@ -1187,21 +1191,6 @@
               denied.textContent = 'Denied';
               denied.addEventListener('click', () => handleUpdateStatus(type, request.id, 'denied'));
               buttonRow.appendChild(denied);
-
-              const ordered = document.createElement('button');
-              ordered.type = 'button';
-              ordered.className = 'secondary';
-              ordered.textContent = 'Ordered';
-              ordered.addEventListener('click', () => {
-                const nextEta = etaInput.value ? etaInput.value.trim() : '';
-                if (!nextEta) {
-                  showToast('Enter an ETA before marking as ordered.');
-                  etaInput.focus();
-                  return;
-                }
-                handleUpdateStatus(type, request.id, 'ordered', { eta: nextEta });
-              });
-              buttonRow.appendChild(ordered);
 
               controls.appendChild(buttonRow);
               item.appendChild(controls);


### PR DESCRIPTION
## Summary
- remove the Ordered action from pending supply requests while leaving the ETA input in place
- update the supplies action button layout to evenly size the remaining controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7c27d068c832287bef9561b91c86e