### PR TITLE
Auto-save ETA selections on supplies requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,6 +355,11 @@
       margin-top: 0.5rem;
     }
 
+    .eta-display {
+      font-size: 0.85rem;
+      color: var(--muted);
+    }
+
     .supplies-actions .inline-buttons {
       display: grid;
       grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
@@ -1171,8 +1176,29 @@
             if (etaValue) {
               etaInput.value = etaValue;
             }
+            let lastEtaValue = etaValue;
+            etaInput.addEventListener('change', () => {
+              const nextEta = etaInput.value ? etaInput.value.trim() : '';
+              if (statusValue === 'ordered' && !nextEta) {
+                showToast('Enter an ETA before saving.');
+                etaInput.value = lastEtaValue;
+                etaInput.focus();
+                return;
+              }
+              lastEtaValue = nextEta;
+              const normalizedStatus = statusValue || 'pending';
+              const targetStatus = request && request.status ? request.status : normalizedStatus;
+              handleUpdateStatus(type, request.id, targetStatus, { eta: nextEta });
+            });
             etaField.appendChild(etaInput);
             controls.appendChild(etaField);
+
+            const etaStatus = document.createElement('span');
+            etaStatus.className = 'eta-display';
+            etaStatus.textContent = etaValue
+              ? `Saved ETA: ${formatEtaDisplay(etaValue)}`
+              : 'Saved ETA: Not set';
+            controls.appendChild(etaStatus);
 
             const buttonRow = document.createElement('div');
             buttonRow.className = 'inline-buttons';
@@ -1206,24 +1232,6 @@
                 handleUpdateStatus(type, request.id, 'ordered', { eta: nextEta });
               });
               buttonRow.appendChild(ordered);
-              hasButtons = true;
-            } else {
-              const saveEta = document.createElement('button');
-              saveEta.type = 'button';
-              saveEta.className = 'secondary';
-              saveEta.textContent = 'Save ETA';
-              saveEta.addEventListener('click', () => {
-                const nextEta = etaInput.value ? etaInput.value.trim() : '';
-                if (String(request.status || '').toLowerCase() === 'ordered' && !nextEta) {
-                  showToast('Enter an ETA before saving.');
-                  etaInput.focus();
-                  return;
-                }
-                const normalizedStatus = statusValue || 'pending';
-                const targetStatus = request && request.status ? request.status : normalizedStatus;
-                handleUpdateStatus(type, request.id, targetStatus, { eta: nextEta });
-              });
-              buttonRow.appendChild(saveEta);
               hasButtons = true;
             }
 
@@ -1317,6 +1325,21 @@
           parts.push(`by ${request.approver}`);
         }
         return parts.join(' • ');
+      }
+
+      function formatEtaDisplay(value) {
+        if (!value) {
+          return '';
+        }
+        try {
+          const date = new Date(value);
+          if (!Number.isNaN(date.getTime())) {
+            return date.toLocaleDateString();
+          }
+        } catch (err) {
+          // ignore parsing issues and fall back to the raw value
+        }
+        return value;
       }
 
       function loadCatalog({ append }) {


### PR DESCRIPTION
## Summary
- auto-save supplies request ETA values as soon as the date picker changes
- surface the persisted ETA directly on each supplies request card
- prevent clearing ETA on ordered requests while keeping existing status actions

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7c73474ac832284acaee07a1fac65