### PR TITLE
Fix status updates for supplies requests

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -344,6 +344,15 @@ function updateRequestStatus(request) {
 
     let updatedRecord = null;
     const headerMap = mapHeaders_(headers);
+    const statusCol = headerMap.status;
+    if (statusCol === undefined) {
+      throw new Error('Request sheet is missing a status column.');
+    }
+    const approverCol = headerMap.approver;
+    if (approverCol === undefined) {
+      throw new Error('Request sheet is missing an approver column.');
+    }
+    const etaCol = headerMap.eta;
     const approverEmail = getActiveUserEmail_();
 
     withLock_(() => {
@@ -355,13 +364,13 @@ function updateRequestStatus(request) {
       const data = dataRange.getValues();
       for (let r = 0; r < data.length; r++) {
         if (String(data[r][idIdx]).trim() === requestId) {
-          data[r][headerMap.status] = status;
-          data[r][headerMap.approver] = approverEmail;
-          sheet.getRange(r + 2, headerMap.status + 1).setValue(status);
-          sheet.getRange(r + 2, headerMap.approver + 1).setValue(approverEmail);
-          if (headerMap.eta !== undefined && hasEta) {
-            data[r][headerMap.eta] = etaValue;
-            sheet.getRange(r + 2, headerMap.eta + 1).setValue(etaValue);
+          data[r][statusCol] = status;
+          data[r][approverCol] = approverEmail;
+          sheet.getRange(r + 2, statusCol + 1).setValue(status);
+          sheet.getRange(r + 2, approverCol + 1).setValue(approverEmail);
+          if (etaCol !== undefined && hasEta) {
+            data[r][etaCol] = etaValue;
+            sheet.getRange(r + 2, etaCol + 1).setValue(etaValue);
           }
           const rowObject = {};
           headers.forEach((header, idx) => {
@@ -578,7 +587,21 @@ function readTable_(sheet, headers) {
 function mapHeaders_(headers) {
   const map = {};
   headers.forEach((header, idx) => {
-    map[header] = idx;
+    const rawKey = String(header || '').trim();
+    if (!rawKey) {
+      return;
+    }
+    if (map[rawKey] === undefined) {
+      map[rawKey] = idx;
+    }
+    const lowerKey = rawKey.toLowerCase();
+    if (map[lowerKey] === undefined) {
+      map[lowerKey] = idx;
+    }
+    const normalizedKey = lowerKey.replace(/\s+/g, '_');
+    if (map[normalizedKey] === undefined) {
+      map[normalizedKey] = idx;
+    }
   });
   return map;
 }


### PR DESCRIPTION
## Summary
- ensure request status updates validate that required sheet columns exist before writing
- normalize header lookups so status updates work even if sheet headers use different casing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d0a5e0588322a89e0bbb11ebdcd6