### PR TITLE
Label submitter and approver on supplies requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -1136,7 +1136,7 @@
 
           const meta = document.createElement('span');
           meta.className = 'meta';
-          meta.textContent = buildRequestMeta(request);
+          meta.textContent = buildRequestMeta(request, type);
           item.appendChild(meta);
 
           const status = document.createElement('span');
@@ -1158,6 +1158,23 @@
           }
 
           if (type === 'supplies') {
+            const submittedLine = document.createElement('span');
+            submittedLine.className = 'detail-line';
+            submittedLine.textContent = `Submitted by: ${request.requester || 'Unknown requester'}`;
+            item.appendChild(submittedLine);
+
+            const decisionLine = document.createElement('span');
+            decisionLine.className = 'detail-line';
+            const approverName = request.approver || 'Not recorded';
+            if (stateKey === 'denied' || stateKey === 'declined') {
+              decisionLine.textContent = `Denied by: ${approverName}`;
+            } else if (stateKey === 'approved' || stateKey === 'ordered' || stateKey === 'completed') {
+              decisionLine.textContent = `Approved by: ${approverName}`;
+            } else {
+              decisionLine.textContent = 'Approval decision pending';
+            }
+            item.appendChild(decisionLine);
+
             const buttonRow = document.createElement('div');
             buttonRow.className = 'inline-buttons';
             let hasButtons = false;
@@ -1261,7 +1278,7 @@
           .updateRequestStatus(payload);
       }
 
-      function buildRequestMeta(request) {
+      function buildRequestMeta(request, type) {
         const parts = [];
         if (request.ts) {
           try {
@@ -1270,10 +1287,10 @@
             parts.push(request.ts);
           }
         }
-        if (request.requester) {
+        if (type !== 'supplies' && request.requester) {
           parts.push(request.requester);
         }
-        if (request.approver && request.status !== 'pending') {
+        if (type !== 'supplies' && request.approver && request.status !== 'pending') {
           parts.push(`by ${request.approver}`);
         }
         return parts.join(' • ');


### PR DESCRIPTION
## Summary
- show labeled submitter and decision maker details inside each supplies request card entry
- avoid duplicating requester and approver in the meta line for supplies entries while keeping other lists unchanged

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d3594cfc8322bf6f6587728c9ebf