### PR TITLE
Fix request meta rendering for scoped views

### DIFF
--- a/index.html
+++ b/index.html
@@ -1444,7 +1444,7 @@
           .updateRequestStatus(payload);
       }
 
-      function buildRequestMeta(request) {
+      function buildRequestMeta(request, type) {
         const parts = [];
         if (request.ts) {
           try {
@@ -1453,10 +1453,11 @@
             parts.push(request.ts);
           }
         }
-        if (type !== 'supplies' && request.requester) {
+        const scopeType = typeof type === 'string' ? type : '';
+        if (scopeType !== 'supplies' && request.requester) {
           parts.push(request.requester);
         }
-        if (type !== 'supplies' && request.approver && request.status !== 'pending') {
+        if (scopeType !== 'supplies' && request.approver && request.status !== 'pending') {
           parts.push(`by ${request.approver}`);
         }
         return parts.join(' • ');


### PR DESCRIPTION
## Summary
- guard the request meta helper against undefined types when rendering request cards
- ensure scoped queue views render without throwing and display requester metadata correctly

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7d7fa733483228a5364e86f401aef