### PR TITLE
Simplify ETA display to date-only format

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -691,13 +691,7 @@ function formatDateForDisplay_(value) {
   if (!normalized) {
     return '';
   }
-  const parts = normalized.split('-');
-  const year = Number(parts[0]);
-  const monthIndex = Number(parts[1]) - 1;
-  const day = Number(parts[2]);
-  const timezone = Session.getScriptTimeZone() || 'UTC';
-  const date = new Date(year, monthIndex, day);
-  return Utilities.formatDate(date, timezone, 'MMM d, yyyy');
+  return normalized;
 }
 
 function toIsoString_(date) {


### PR DESCRIPTION
## Summary
- ensure saved ETA values for supplies requests display as their raw YYYY-MM-DD date so no time or timezone appears

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7de40f6988322bdd29e5837e3bf61