### PR TITLE
Remove unused scope metadata from request listing

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -202,12 +202,10 @@ function listRequests(request) {
     ensureSetup_();
     const type = normalizeType_(request && request.type);
     const def = REQUEST_TYPES[type];
-    const scope = 'all';
-    const scopeKey = 'all';
     const pageSize = clamp_(Number(request && request.pageSize) || 15, 1, MAX_PAGE_SIZE);
     const startIndex = Number(request && request.nextToken) || 0;
 
-    const cacheKey = [CACHE_KEYS.REQUESTS_PREFIX, type, scopeKey].join(':');
+    const cacheKey = [CACHE_KEYS.REQUESTS_PREFIX, type, 'all'].join(':');
     const cache = CacheService.getScriptCache();
     let records = [];
     const cached = cache.get(cacheKey);
@@ -228,8 +226,7 @@ function listRequests(request) {
       ok: true,
       type,
       requests: slice,
-      nextToken,
-      scope
+      nextToken
     };
   });
 }


### PR DESCRIPTION
## Summary
- remove unused `scope` metadata from the `listRequests` handler to reduce unnecessary state
- simplify cache key construction by inlining the all-scope token

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e23785848322ba4c6a43ffd05d53