### PR TITLE
Ensure IT and maintenance request cards show submitter and status actor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1205,24 +1205,20 @@
             });
           }
 
+          const submittedLine = document.createElement('span');
+          submittedLine.className = 'detail-line';
+          submittedLine.textContent = `Submitted by: ${request.requester || 'Unknown requester'}`;
+          item.appendChild(submittedLine);
+
+          const statusLineText = buildStatusActorLine(type, stateKey, request.approver);
+          if (statusLineText) {
+            const statusLine = document.createElement('span');
+            statusLine.className = 'detail-line';
+            statusLine.textContent = statusLineText;
+            item.appendChild(statusLine);
+          }
+
           if (type === 'supplies') {
-            const submittedLine = document.createElement('span');
-            submittedLine.className = 'detail-line';
-            submittedLine.textContent = `Submitted by: ${request.requester || 'Unknown requester'}`;
-            item.appendChild(submittedLine);
-
-            const decisionLine = document.createElement('span');
-            decisionLine.className = 'detail-line';
-            const approverName = request.approver || 'Not recorded';
-            if (stateKey === 'denied' || stateKey === 'declined') {
-              decisionLine.textContent = `Denied by: ${approverName}`;
-            } else if (stateKey === 'approved' || stateKey === 'ordered' || stateKey === 'completed') {
-              decisionLine.textContent = `Approved by: ${approverName}`;
-            } else {
-              decisionLine.textContent = 'Approval decision pending';
-            }
-            item.appendChild(decisionLine);
-
             const buttonRow = document.createElement('div');
             buttonRow.className = 'inline-buttons';
             let hasButtons = false;
@@ -1383,9 +1379,6 @@
         const scopeType = typeof type === 'string' ? type : '';
         if (scopeType !== 'supplies' && request.requester) {
           parts.push(request.requester);
-        }
-        if (scopeType !== 'supplies' && request.approver && request.status !== 'pending') {
-          parts.push(`by ${request.approver}`);
         }
         return parts.join(' • ');
       }
@@ -1630,6 +1623,27 @@
             return 'Declined';
           default:
             return 'Pending review';
+        }
+      }
+
+      function buildStatusActorLine(type, statusKey, approver) {
+        const actorName = approver ? approver : 'Not recorded';
+        switch (statusKey) {
+          case 'denied':
+          case 'declined':
+            return `Denied by: ${actorName}`;
+          case 'approved':
+            return `Approved by: ${actorName}`;
+          case 'ordered':
+            return `Ordered by: ${actorName}`;
+          case 'completed':
+            return `Completed by: ${actorName}`;
+          case 'in_progress':
+            return `In progress by: ${actorName}`;
+          case 'pending':
+            return type === 'supplies' ? 'Approval decision pending' : 'Update pending';
+          default:
+            return `Status: ${formatStatus(statusKey)}${approver ? ` by ${actorName}` : ''}`;
         }
       }
 


### PR DESCRIPTION
## Summary
- align IT and maintenance request cards with the supplies card format by rendering shared "Submitted by" and status owner lines
- add a helper to describe who approved, ordered, completed, or denied each request so status updates remain transparent across request types
- remove duplicate approver text from non-supplies card metadata to keep the presentation consistent

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d7e410909083229bc6db90ef55d410