### PR TITLE
Enhance catalog picker for supplies requests

### DIFF
--- a/index.html
+++ b/index.html
@@ -312,6 +312,12 @@
     .catalog-field {
       display: flex;
       flex-direction: column;
+      gap: 0.75rem;
+    }
+
+    .catalog-picker {
+      display: flex;
+      flex-direction: column;
       gap: 0.5rem;
     }
 
@@ -335,11 +341,132 @@
       -webkit-appearance: none;
     }
 
+    .catalog-suggestions {
+      display: flex;
+      flex-direction: column;
+      gap: 0.5rem;
+    }
+
+    .catalog-suggestions[hidden] {
+      display: none;
+    }
+
+    .catalog-suggestion {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.2rem;
+      padding: 0.65rem 0.75rem;
+      border-radius: 12px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: inherit;
+      text-align: left;
+      transition: border 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+      cursor: pointer;
+    }
+
+    .catalog-suggestion .label {
+      font-size: 0.95rem;
+      font-weight: 600;
+    }
+
+    .catalog-suggestion .meta {
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    .catalog-suggestion .meta.usage {
+      color: var(--accent-strong);
+      font-weight: 500;
+    }
+
+    .catalog-suggestion:hover,
+    .catalog-suggestion:focus {
+      border-color: rgba(11, 87, 208, 0.4);
+      background: rgba(11, 87, 208, 0.05);
+      box-shadow: 0 6px 12px -10px rgba(11, 87, 208, 0.4);
+      outline: none;
+    }
+
+    .catalog-suggestion.selected {
+      border-color: rgba(11, 87, 208, 0.65);
+      background: rgba(11, 87, 208, 0.08);
+      box-shadow: 0 0 0 1px rgba(11, 87, 208, 0.35);
+    }
+
+    .catalog-selected {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0.75rem;
+      padding: 0.75rem 0.9rem;
+      border-radius: 12px;
+      border: 1px solid rgba(11, 87, 208, 0.25);
+      background: rgba(11, 87, 208, 0.08);
+    }
+
+    .catalog-selected[hidden] {
+      display: none;
+    }
+
+    .catalog-selected strong {
+      font-size: 0.95rem;
+    }
+
+    .catalog-selected .meta {
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    .catalog-selected .meta.usage {
+      color: var(--accent-strong);
+      font-weight: 600;
+    }
+
+    .catalog-selected-details {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .catalog-clear {
+      padding: 0.45rem 0.9rem;
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      color: var(--accent);
+      font-weight: 600;
+      font-size: 0.85rem;
+      transition: background 0.2s ease, border 0.2s ease;
+    }
+
+    .catalog-clear:hover:not([disabled]) {
+      background: #e9eef7;
+      border-color: rgba(11, 87, 208, 0.4);
+    }
+
+    .catalog-clear[disabled] {
+      opacity: 0.6;
+      cursor: not-allowed;
+    }
+
     .input-helper {
       margin-top: 0.35rem;
       font-size: 0.8rem;
       color: var(--muted);
       display: block;
+    }
+
+    .visually-hidden {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      border: 0;
     }
 
     .catalog-item.selected {
@@ -582,19 +709,37 @@
         <div class="card-body">
           <form id="suppliesForm" class="form-grid" novalidate>
             <label class="full-width">
-              <span>Catalog</span>
+              <span>Catalog item</span>
               <div class="catalog-field">
-                <div class="catalog-search">
-                  <input
-                    id="catalogSearch"
-                    type="search"
-                    name="catalogSearch"
-                    placeholder="Search the catalog"
-                    autocomplete="off"
-                    spellcheck="false"
-                  >
+                <div class="catalog-picker" role="group" aria-label="Catalog quick pick">
+                  <div class="catalog-search">
+                    <input
+                      id="catalogSearch"
+                      type="search"
+                      name="catalogSearch"
+                      placeholder="Search by name, category, or SKU"
+                      autocomplete="off"
+                      spellcheck="false"
+                      aria-controls="catalogSuggestionList"
+                    >
+                  </div>
+                  <div
+                    id="catalogSuggestionList"
+                    class="catalog-suggestions"
+                    role="listbox"
+                    aria-label="Top catalog matches"
+                    hidden
+                  ></div>
+                  <div id="catalogSelected" class="catalog-selected" hidden>
+                    <div class="catalog-selected-details">
+                      <strong id="catalogSelectedName"></strong>
+                      <span id="catalogSelectedMeta" class="meta"></span>
+                      <span id="catalogSelectedUsage" class="meta usage"></span>
+                    </div>
+                    <button type="button" id="catalogClearButton" class="catalog-clear">Clear</button>
+                  </div>
                 </div>
-                <select id="catalogSelect" name="catalogSku"></select>
+                <select id="catalogSelect" name="catalogSku" class="visually-hidden" tabindex="-1" aria-hidden="true"></select>
               </div>
               <span class="input-helper">Can't find it? Enter a custom item name below.</span>
             </label>
@@ -875,6 +1020,12 @@
           more: document.getElementById('suppliesMoreButton'),
           catalogSearch: document.getElementById('catalogSearch'),
           catalogSelect: document.getElementById('catalogSelect'),
+          catalogSuggestions: document.getElementById('catalogSuggestionList'),
+          catalogSelected: document.getElementById('catalogSelected'),
+          catalogSelectedName: document.getElementById('catalogSelectedName'),
+          catalogSelectedMeta: document.getElementById('catalogSelectedMeta'),
+          catalogSelectedUsage: document.getElementById('catalogSelectedUsage'),
+          catalogClear: document.getElementById('catalogClearButton'),
           catalogList: document.getElementById('catalogList'),
           catalogMore: document.getElementById('catalogMoreButton')
         },
@@ -991,16 +1142,26 @@
         dom.supplies.catalogSelect.addEventListener('change', () => {
           const option = dom.supplies.catalogSelect.options[dom.supplies.catalogSelect.selectedIndex];
           const sku = option ? option.value : '';
+          const existingDescription = state.forms.supplies.description || '';
           const description = option && option.dataset ? (option.dataset.description || '') : '';
+          const nextDescription = sku ? description : existingDescription;
           syncingCatalogToDescription = true;
-          dom.supplies.description.value = description;
+          dom.supplies.description.value = nextDescription;
           syncingCatalogToDescription = false;
-          setFormState('supplies', { catalogSku: sku, description });
+          setFormState('supplies', { catalogSku: sku, description: nextDescription });
           persistForm('supplies');
           if (state.catalog.items.length) {
             renderCatalog();
           }
         });
+        if (dom.supplies.catalogClear) {
+          dom.supplies.catalogClear.addEventListener('click', () => {
+            selectCatalogSku('');
+            if (dom.supplies.catalogSearch) {
+              dom.supplies.catalogSearch.focus();
+            }
+          });
+        }
         dom.supplies.more.addEventListener('click', () => {
           if (!state.loading.supplies && state.nextTokens.supplies) {
             loadRequests('supplies', { append: true });
@@ -1586,9 +1747,13 @@
       function renderCatalog() {
         dom.supplies.catalogList.textContent = '';
         dom.supplies.catalogSelect.textContent = '';
+        let selectedSku = state.forms.supplies.catalogSku || '';
         const searchValue = state.catalog.search || '';
         dom.supplies.catalogSearch.value = searchValue;
         updateCatalogControls();
+
+        updateCatalogSuggestions([], selectedSku);
+        updateCatalogSelectionSummary(findCatalogItem(selectedSku));
 
         const defaultOption = document.createElement('option');
         defaultOption.value = '';
@@ -1615,7 +1780,6 @@
 
         dom.supplies.catalogSearch.disabled = false;
 
-        let selectedSku = state.forms.supplies.catalogSku || '';
         const descriptionValue = (state.forms.supplies.description || '').trim();
         let shouldPersist = false;
         if (!selectedSku && descriptionValue) {
@@ -1629,6 +1793,8 @@
             shouldPersist = true;
           }
         }
+
+        updateCatalogSelectionSummary(findCatalogItem(selectedSku));
 
         const normalizedSearch = searchValue.trim().toLowerCase();
         let filteredItems = state.catalog.items.slice();
@@ -1646,6 +1812,7 @@
         }
 
         if (!filteredItems.length) {
+          updateCatalogSuggestions([], selectedSku);
           const empty = document.createElement('p');
           empty.className = 'empty';
           if (normalizedSearch) {
@@ -1659,6 +1826,8 @@
           dom.supplies.catalogSelect.disabled = true;
           return;
         }
+
+        updateCatalogSuggestions(filteredItems, selectedSku);
 
         const popularItems = state.catalog.items.filter(item => Number(item.usageCount) > 0);
         const topRank = Math.min(5, popularItems.length);
@@ -1706,8 +1875,7 @@
             card.appendChild(badge);
           }
           const handleSelect = () => {
-            dom.supplies.catalogSelect.value = item.sku;
-            dom.supplies.catalogSelect.dispatchEvent(new Event('change'));
+            selectCatalogSku(item.sku);
           };
           card.addEventListener('click', () => {
             handleSelect();
@@ -1732,6 +1900,119 @@
         if (shouldPersist) {
           persistForm('supplies');
         }
+      }
+
+      function updateCatalogSuggestions(items, selectedSku) {
+        const container = dom.supplies.catalogSuggestions;
+        if (!container) {
+          return;
+        }
+        container.textContent = '';
+        let suggestions = Array.isArray(items) ? items.slice(0, 3) : [];
+        if (selectedSku) {
+          const selectedItem = (Array.isArray(items) ? items : []).find(entry => entry.sku === selectedSku) || findCatalogItem(selectedSku);
+          if (selectedItem && !suggestions.some(entry => entry.sku === selectedSku)) {
+            suggestions.unshift(selectedItem);
+          }
+        }
+        suggestions = suggestions.slice(0, 3);
+        if (!suggestions.length) {
+          container.hidden = true;
+          container.setAttribute('aria-hidden', 'true');
+          return;
+        }
+        const fragment = document.createDocumentFragment();
+        suggestions.forEach(item => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'catalog-suggestion';
+          if (item.sku === selectedSku) {
+            button.classList.add('selected');
+          }
+          button.setAttribute('role', 'option');
+          button.setAttribute('aria-selected', item.sku === selectedSku ? 'true' : 'false');
+          button.addEventListener('click', () => {
+            selectCatalogSku(item.sku);
+          });
+          const label = document.createElement('span');
+          label.className = 'label';
+          label.textContent = item.description;
+          button.appendChild(label);
+          const meta = document.createElement('span');
+          meta.className = 'meta';
+          meta.textContent = item.category ? `${item.category} • ${item.sku}` : item.sku;
+          button.appendChild(meta);
+          if (Number(item.usageCount) > 0) {
+            const usage = document.createElement('span');
+            usage.className = 'meta usage';
+            usage.textContent = item.usageCount === 1 ? 'Requested 1 time' : `Requested ${item.usageCount} times`;
+            button.appendChild(usage);
+          }
+          fragment.appendChild(button);
+        });
+        container.hidden = false;
+        container.setAttribute('aria-hidden', 'false');
+        container.appendChild(fragment);
+      }
+
+      function updateCatalogSelectionSummary(item) {
+        const container = dom.supplies.catalogSelected;
+        if (!container) {
+          return;
+        }
+        if (!item) {
+          container.hidden = true;
+          if (dom.supplies.catalogSelectedName) {
+            dom.supplies.catalogSelectedName.textContent = '';
+          }
+          if (dom.supplies.catalogSelectedMeta) {
+            dom.supplies.catalogSelectedMeta.textContent = '';
+          }
+          if (dom.supplies.catalogSelectedUsage) {
+            dom.supplies.catalogSelectedUsage.textContent = '';
+            dom.supplies.catalogSelectedUsage.hidden = true;
+          }
+          if (dom.supplies.catalogClear) {
+            dom.supplies.catalogClear.disabled = true;
+          }
+          container.setAttribute('aria-hidden', 'true');
+          return;
+        }
+        container.hidden = false;
+        container.setAttribute('aria-hidden', 'false');
+        if (dom.supplies.catalogSelectedName) {
+          dom.supplies.catalogSelectedName.textContent = item.description || '';
+        }
+        if (dom.supplies.catalogSelectedMeta) {
+          dom.supplies.catalogSelectedMeta.textContent = item.category ? `${item.category} • ${item.sku}` : item.sku || '';
+        }
+        if (dom.supplies.catalogSelectedUsage) {
+          if (Number(item.usageCount) > 0) {
+            dom.supplies.catalogSelectedUsage.hidden = false;
+            dom.supplies.catalogSelectedUsage.textContent = item.usageCount === 1
+              ? 'Requested 1 time'
+              : `Requested ${item.usageCount} times`;
+          } else {
+            dom.supplies.catalogSelectedUsage.textContent = '';
+            dom.supplies.catalogSelectedUsage.hidden = true;
+          }
+        }
+        if (dom.supplies.catalogClear) {
+          dom.supplies.catalogClear.disabled = false;
+        }
+      }
+
+      function selectCatalogSku(sku) {
+        dom.supplies.catalogSelect.value = sku || '';
+        dom.supplies.catalogSelect.dispatchEvent(new Event('change'));
+      }
+
+      function findCatalogItem(sku) {
+        if (!sku) {
+          return null;
+        }
+        const item = state.catalog.items.find(entry => entry.sku === sku);
+        return item || null;
       }
 
       function ensureFullCatalogLoaded() {


### PR DESCRIPTION
## Summary
- redesign the supplies catalog field into a single picker with inline search, smart suggestions, and a selection summary
- add frontend logic to surface quick matches, persist selections, and offer a clear action while keeping the catalog list in sync

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d805dd50e0832290a1fa4633ead309