### PR TITLE
Enhance catalog search dropdown UX

### DIFF
--- a/index.html
+++ b/index.html
@@ -328,7 +328,7 @@
     .catalog-search::after {
       content: '\1F50D';
       position: absolute;
-      right: 0.75rem;
+      right: 3.15rem;
       top: 50%;
       transform: translateY(-50%);
       pointer-events: none;
@@ -337,8 +337,109 @@
     }
 
     .catalog-search input[type="search"] {
-      padding-right: 2.25rem;
+      padding-right: 4.75rem;
       -webkit-appearance: none;
+    }
+
+    .catalog-clear {
+      position: absolute;
+      top: 50%;
+      right: 0.65rem;
+      transform: translateY(-50%);
+      width: 36px;
+      height: 36px;
+      border-radius: 999px;
+      border: none;
+      background: rgba(32, 39, 49, 0.08);
+      color: var(--text);
+      font-size: 1.35rem;
+      font-weight: 700;
+      line-height: 1;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      cursor: pointer;
+      opacity: 0;
+      pointer-events: none;
+      transition: opacity 0.15s ease, transform 0.15s ease, background 0.15s ease;
+    }
+
+    .catalog-clear.visible {
+      opacity: 1;
+      pointer-events: auto;
+    }
+
+    .catalog-clear:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
+    }
+
+    .catalog-clear:hover {
+      background: rgba(32, 39, 49, 0.14);
+      transform: translateY(-50%) scale(1.05);
+    }
+
+    .catalog-suggestions {
+      position: absolute;
+      top: calc(100% + 0.35rem);
+      left: 0;
+      width: 100%;
+      max-height: 240px;
+      overflow-y: auto;
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      background: var(--surface);
+      box-shadow: 0 18px 36px -24px rgba(23, 32, 42, 0.55);
+      padding: 0.35rem 0;
+      display: none;
+      z-index: 20;
+    }
+
+    .catalog-suggestions.open {
+      display: block;
+    }
+
+    .catalog-suggestion,
+    .catalog-suggestion-empty {
+      width: 100%;
+      padding: 0.65rem 1rem;
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+      gap: 0.2rem;
+    }
+
+    .catalog-suggestion {
+      border: none;
+      background: transparent;
+      text-align: left;
+      cursor: pointer;
+      color: inherit;
+      font: inherit;
+    }
+
+    .catalog-suggestion:focus-visible {
+      outline: none;
+    }
+
+    .catalog-suggestion:hover,
+    .catalog-suggestion.active {
+      background: rgba(11, 87, 208, 0.08);
+    }
+
+    .catalog-suggestion span.primary {
+      font-weight: 600;
+      font-size: 0.98rem;
+    }
+
+    .catalog-suggestion span.meta {
+      font-size: 0.8rem;
+      color: var(--muted);
+    }
+
+    .catalog-suggestion-empty {
+      color: var(--muted);
+      font-size: 0.85rem;
     }
 
     datalist option {
@@ -646,7 +747,12 @@
                       autocomplete="off"
                       spellcheck="false"
                       list="catalogOptions"
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-controls="catalogSuggestions"
                     >
+                    <button type="button" id="catalogClearButton" class="catalog-clear" aria-label="Clear selected catalog item">×</button>
+                    <div id="catalogSuggestions" class="catalog-suggestions" role="listbox" aria-label="Catalog suggestions" aria-hidden="true"></div>
                     <datalist id="catalogOptions"></datalist>
                   </div>
                 </div>
@@ -909,7 +1015,10 @@
           nextToken: '',
           loading: false,
           search: '',
-          fullyLoaded: false
+          fullyLoaded: false,
+          suggestionsOpen: false,
+          visibleSuggestions: [],
+          activeSuggestion: -1
         }
       };
 
@@ -931,7 +1040,9 @@
           catalogOptions: document.getElementById('catalogOptions'),
           catalogSku: document.getElementById('catalogSkuField'),
           catalogList: document.getElementById('catalogList'),
-          catalogMore: document.getElementById('catalogMoreButton')
+          catalogMore: document.getElementById('catalogMoreButton'),
+          catalogClear: document.getElementById('catalogClearButton'),
+          catalogSuggestions: document.getElementById('catalogSuggestions')
         },
         it: {
           form: document.getElementById('itForm'),
@@ -1032,6 +1143,24 @@
         });
         dom.supplies.catalogSearch.addEventListener('focus', () => {
           ensureFullCatalogLoaded();
+          setCatalogSuggestionsOpen(true, { resetActive: true });
+          updateCatalogSearchAffordances();
+        });
+        dom.supplies.catalogSearch.addEventListener('click', () => {
+          ensureFullCatalogLoaded();
+          setCatalogSuggestionsOpen(true);
+        });
+        dom.supplies.catalogSearch.addEventListener('blur', () => {
+          window.setTimeout(() => {
+            const active = document.activeElement;
+            const withinCombobox =
+              active === dom.supplies.catalogSearch ||
+              (dom.supplies.catalogClear && active === dom.supplies.catalogClear) ||
+              (dom.supplies.catalogSuggestions && active instanceof Node && dom.supplies.catalogSuggestions.contains(active));
+            if (!withinCombobox) {
+              setCatalogSuggestionsOpen(false, { resetActive: true });
+            }
+          }, 120);
         });
         const handleCatalogSearchInput = () => {
           const rawValue = dom.supplies.catalogSearch.value || '';
@@ -1046,9 +1175,37 @@
           if (state.catalog.items.length) {
             renderCatalog();
           }
+          updateCatalogSearchAffordances();
+          setCatalogSuggestionsOpen(true);
         };
         dom.supplies.catalogSearch.addEventListener('input', handleCatalogSearchInput);
         dom.supplies.catalogSearch.addEventListener('change', handleCatalogSearchInput);
+        dom.supplies.catalogSearch.addEventListener('keydown', handleCatalogSearchKeydown);
+        if (dom.supplies.catalogClear) {
+          dom.supplies.catalogClear.addEventListener('click', () => {
+            dom.supplies.catalogSearch.value = '';
+            state.catalog.search = '';
+            selectCatalogSku('', { updateSearch: false, preserveDescription: true });
+            renderCatalog();
+            updateCatalogSearchAffordances();
+            setCatalogSuggestionsOpen(true, { resetActive: true });
+            dom.supplies.catalogSearch.focus();
+          });
+        }
+        if (dom.supplies.catalogSuggestions) {
+          dom.supplies.catalogSuggestions.addEventListener('mousedown', evt => {
+            const target = evt.target instanceof Element ? evt.target.closest('.catalog-suggestion') : null;
+            if (target) {
+              evt.preventDefault();
+            }
+          });
+          dom.supplies.catalogSuggestions.addEventListener('touchstart', evt => {
+            const target = evt.target instanceof Element ? evt.target.closest('.catalog-suggestion') : null;
+            if (target) {
+              evt.preventDefault();
+            }
+          }, { passive: false });
+        }
         dom.supplies.more.addEventListener('click', () => {
           if (!state.loading.supplies && state.nextTokens.supplies) {
             loadRequests('supplies', { append: true });
@@ -1683,6 +1840,8 @@
         let selectedSku = state.forms.supplies.catalogSku || '';
         const searchValue = state.catalog.search || '';
         dom.supplies.catalogSearch.value = searchValue;
+        updateCatalogSearchAffordances();
+        renderCatalogSuggestions();
         updateCatalogControls();
 
         if (!state.catalog.items.length) {
@@ -1795,6 +1954,7 @@
             card.appendChild(badge);
           }
           const handleSelect = () => {
+            setCatalogSuggestionsOpen(false, { resetActive: true });
             selectCatalogSku(item.sku);
             renderCatalog();
           };
@@ -1815,6 +1975,179 @@
           loading.className = 'meta';
           loading.textContent = 'Loading remaining catalog items…';
           dom.supplies.catalogList.appendChild(loading);
+        }
+      }
+
+      function renderCatalogSuggestions() {
+        const container = dom.supplies.catalogSuggestions;
+        if (!container) {
+          return;
+        }
+        if (!state.catalog.suggestionsOpen) {
+          container.textContent = '';
+          container.classList.remove('open');
+          container.setAttribute('aria-hidden', 'true');
+          state.catalog.visibleSuggestions = [];
+          return;
+        }
+        container.textContent = '';
+        container.classList.add('open');
+        container.setAttribute('aria-hidden', 'false');
+        const normalizedSearch = (dom.supplies.catalogSearch.value || '').trim().toLowerCase();
+        let suggestions = state.catalog.items.slice();
+        if (normalizedSearch) {
+          suggestions = suggestions.filter(item => {
+            const haystack = `${item.description} ${item.category || ''} ${item.sku}`.toLowerCase();
+            return haystack.indexOf(normalizedSearch) !== -1;
+          });
+        } else {
+          const popular = state.catalog.items.filter(item => Number(item.usageCount) > 0);
+          if (popular.length) {
+            suggestions = popular;
+          }
+        }
+        const limit = 8;
+        suggestions = suggestions.slice(0, limit);
+        state.catalog.visibleSuggestions = suggestions;
+        if (!suggestions.length) {
+          const empty = document.createElement('div');
+          empty.className = 'catalog-suggestion-empty';
+          empty.textContent = state.catalog.loading
+            ? 'Loading catalog…'
+            : 'Keep typing to search the catalog.';
+          container.appendChild(empty);
+          state.catalog.activeSuggestion = -1;
+          return;
+        }
+        if (state.catalog.activeSuggestion >= suggestions.length) {
+          state.catalog.activeSuggestion = -1;
+        }
+        suggestions.forEach((item, index) => {
+          const button = document.createElement('button');
+          button.type = 'button';
+          button.className = 'catalog-suggestion';
+          if (index === state.catalog.activeSuggestion) {
+            button.classList.add('active');
+          }
+          button.setAttribute('role', 'option');
+          button.setAttribute('aria-selected', index === state.catalog.activeSuggestion ? 'true' : 'false');
+          button.dataset.index = String(index);
+          button.dataset.sku = item.sku;
+          const primary = document.createElement('span');
+          primary.className = 'primary';
+          primary.textContent = item.description;
+          button.appendChild(primary);
+          const meta = document.createElement('span');
+          meta.className = 'meta';
+          meta.textContent = item.category ? `${item.category} • ${item.sku}` : item.sku;
+          button.appendChild(meta);
+          button.addEventListener('mouseenter', () => {
+            setActiveCatalogSuggestion(index);
+          });
+          button.addEventListener('focus', () => {
+            setActiveCatalogSuggestion(index);
+          });
+          button.addEventListener('click', () => {
+            setCatalogSuggestionsOpen(false, { resetActive: true });
+            selectCatalogSku(item.sku);
+            renderCatalog();
+            updateCatalogSearchAffordances();
+          });
+          container.appendChild(button);
+        });
+      }
+
+      function setCatalogSuggestionsOpen(open, options) {
+        const container = dom.supplies.catalogSuggestions;
+        if (!container) {
+          state.catalog.suggestionsOpen = false;
+          return;
+        }
+        const resetActive = Boolean(options && options.resetActive);
+        state.catalog.suggestionsOpen = Boolean(open);
+        if (resetActive) {
+          state.catalog.activeSuggestion = -1;
+        }
+        dom.supplies.catalogSearch.setAttribute('aria-expanded', state.catalog.suggestionsOpen ? 'true' : 'false');
+        container.classList.toggle('open', state.catalog.suggestionsOpen);
+        container.setAttribute('aria-hidden', state.catalog.suggestionsOpen ? 'false' : 'true');
+        if (state.catalog.suggestionsOpen) {
+          renderCatalogSuggestions();
+        } else {
+          state.catalog.visibleSuggestions = [];
+          container.textContent = '';
+        }
+      }
+
+      function setActiveCatalogSuggestion(index) {
+        state.catalog.activeSuggestion = typeof index === 'number' ? index : -1;
+        const container = dom.supplies.catalogSuggestions;
+        if (!container) {
+          return;
+        }
+        const buttons = Array.from(container.querySelectorAll('.catalog-suggestion'));
+        buttons.forEach((button, idx) => {
+          const isActive = idx === state.catalog.activeSuggestion;
+          button.classList.toggle('active', isActive);
+          button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+        });
+      }
+
+      function updateCatalogSearchAffordances() {
+        if (!dom.supplies.catalogClear) {
+          return;
+        }
+        const hasValue = Boolean(dom.supplies.catalogSearch.value);
+        const hasSelection = Boolean(dom.supplies.catalogSku.value);
+        dom.supplies.catalogClear.classList.toggle('visible', hasValue || hasSelection);
+      }
+
+      function handleCatalogSearchKeydown(evt) {
+        const key = evt.key;
+        if (key === 'ArrowDown' || key === 'ArrowUp') {
+          if (!state.catalog.suggestionsOpen) {
+            setCatalogSuggestionsOpen(true, { resetActive: true });
+          }
+          if (!state.catalog.visibleSuggestions.length) {
+            return;
+          }
+          evt.preventDefault();
+          const maxIndex = state.catalog.visibleSuggestions.length - 1;
+          let nextIndex = state.catalog.activeSuggestion;
+          if (key === 'ArrowDown') {
+            nextIndex = nextIndex >= maxIndex ? 0 : nextIndex + 1;
+          } else {
+            nextIndex = nextIndex <= 0 ? maxIndex : nextIndex - 1;
+          }
+          setActiveCatalogSuggestion(nextIndex);
+          const container = dom.supplies.catalogSuggestions;
+          if (container) {
+            const buttons = container.querySelectorAll('.catalog-suggestion');
+            const active = buttons[nextIndex];
+            if (active && active.scrollIntoView) {
+              active.scrollIntoView({ block: 'nearest' });
+            }
+          }
+          return;
+        }
+        if (key === 'Enter') {
+          if (state.catalog.suggestionsOpen && state.catalog.activeSuggestion > -1) {
+            const item = state.catalog.visibleSuggestions[state.catalog.activeSuggestion];
+            if (item) {
+              evt.preventDefault();
+              setCatalogSuggestionsOpen(false, { resetActive: true });
+              selectCatalogSku(item.sku);
+              renderCatalog();
+              updateCatalogSearchAffordances();
+            }
+          }
+          return;
+        }
+        if (key === 'Escape') {
+          if (state.catalog.suggestionsOpen) {
+            evt.preventDefault();
+            setCatalogSuggestionsOpen(false, { resetActive: true });
+          }
         }
       }
 
@@ -1840,6 +2173,7 @@
         }
         dom.supplies.catalogSku.value = sku || '';
         setFormState('supplies', { catalogSku: sku || '', description: nextDescription });
+        updateCatalogSearchAffordances();
         if (opts.persist !== false) {
           persistForm('supplies');
         }


### PR DESCRIPTION
## Summary
- add an explicit clear control and richer styling to the catalog search field
- surface an inline suggestion panel with keyboard support and accessible focus handling
- keep catalog form state, combobox affordances, and suggestions synchronized when selections change

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d81c48843c83229629fd120f982d9a