### PR TITLE
Improve session bootstrap fallback

### DIFF
--- a/Code.gs
+++ b/Code.gs
@@ -1,4 +1,5 @@
 /* eslint-env googleappsscript */
+/* global ScriptApp */
 
 const SCRIPT_PROP_SHEET_ID = 'SUPPLIES_TRACKING_SHEET_ID';
 const SCRIPT_PROP_SETUP_VERSION = 'SUPPLIES_TRACKING_SETUP_VERSION';

--- a/index.html
+++ b/index.html
@@ -2851,8 +2851,26 @@
 
   <?!= include('scripts'); ?>
 
+  <script id="sessionData" type="application/json">
+    <?!= JSON.stringify(session) ?>
+  </script>
   <script>
-    const SESSION = <?!= JSON.stringify(session) ?>;
+    const SESSION = (() => {
+      const script = document.getElementById('sessionData');
+      if (!script) {
+        return {};
+      }
+      const raw = (script.textContent || '').trim();
+      if (!raw || raw.startsWith('<')) {
+        return {};
+      }
+      try {
+        return JSON.parse(raw);
+      } catch (err) {
+        console.warn('SESSION payload is invalid. Falling back to anonymous session.', err);
+        return {};
+      }
+    })();
   </script>
   <script>
     (function () {


### PR DESCRIPTION
## Summary
- add a safe session bootstrap that tolerates missing Apps Script templating
- declare ScriptApp as a global for linting without disabling the env

## Testing
- npm test
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6924f314c1d0832ea12f603cf31ab9a2)